### PR TITLE
Features/qbatch acquisitions

### DIFF
--- a/src/activelearning/acquisition/botorch/botorch_acquisition.py
+++ b/src/activelearning/acquisition/botorch/botorch_acquisition.py
@@ -383,6 +383,69 @@ class AnalyticBoTorchAcquisition(BoTorchAcquisitionBase):
         super().__init__(**kwargs)
 
 
+class BatchScoringMixin:
+    """Adds joint batch scoring to a q-batch acquisition.
+
+    BoTorch q-batch acquisitions naturally operate on batches of candidates
+    evaluated jointly. However, not all of them support this mode — some
+    (e.g. MES, Knowledge Gradient) are constrained to evaluating one candidate
+    at a time despite using Monte Carlo internals.
+
+    Add this class as a base to enable ``score_batches()`` for acquisitions
+    that do support joint evaluation::
+
+        class QExpectedImprovement(BatchScoringMixin, QBatchBoTorchAcquisition):
+            ...
+
+    Omit it for acquisitions that only support singleton scoring::
+
+        class QKnowledgeGradient(QBatchBoTorchAcquisition):
+            ...
+    """
+
+    def score_batches(
+        self,
+        candidate_batches: Iterable[Iterable[Candidate]],
+        cost_weighting: Optional[
+            Callable[[list[float], list[list[Candidate]]], list[float]]
+        ] = None,
+    ) -> list[float]:
+        """Score candidate batches jointly using q-batch semantics.
+
+        Returns a constant score of ``1.0`` for every batch when the
+        acquisition has not yet been coupled to a fitted surrogate. This
+        allows the active learning loop to sample batches uniformly on
+        the first round before any observations are available.
+
+        Parameters
+        ----------
+        candidate_batches : Iterable[Iterable[Candidate]]
+            Iterable of candidate batches. Each inner iterable represents one
+            jointly scored batch.
+        cost_weighting : callable, optional
+            If provided, called as ``cost_weighting(raw_scores, batches)``
+            after scoring and its return value is used in place of the raw
+            scores. Not applied before ``update()`` has been called.
+
+        Returns
+        -------
+        result : list[float]
+            Acquisition scores in the same order as the input batches.
+            All ``1.0`` when called before ``update()``.
+        """
+        batch_list = [b if isinstance(b, list) else list(b) for b in candidate_batches]
+        if not batch_list:
+            return []
+        if self._botorch_acqf is None:  # type: ignore[attr-defined]
+            return [1.0] * len(batch_list)
+        assert self._botorch_surrogate is not None  # type: ignore[attr-defined]
+        X = self._botorch_surrogate.encode_candidate_batches(batch_list)  # (B, q, d)
+        raw_scores = self._score_encoded(X)  # type: ignore[attr-defined]
+        if cost_weighting is None:
+            return raw_scores
+        return cost_weighting(raw_scores, batch_list)
+
+
 class QBatchBoTorchAcquisition(BoTorchAcquisitionBase):
     """Intermediate base class for q-batch / Monte Carlo BoTorch acquisitions.
 

--- a/src/activelearning/acquisition/botorch/botorch_multifidelity.py
+++ b/src/activelearning/acquisition/botorch/botorch_multifidelity.py
@@ -6,6 +6,7 @@ Each class subclasses :class:`QBatchBoTorchAcquisition` and implements
 and target-fidelity projection from the base class into the BoTorch object.
 """
 
+import warnings
 from typing import Any, Callable, ClassVar, Iterable, Optional
 
 import torch
@@ -112,6 +113,14 @@ class _QMultiFidelityEntropyBase(QBatchBoTorchAcquisition):
             self._candidate_set_spec.update(obs_list)
             super().update(surrogate, obs_list)
         else:
+            if type(self._candidate_set_spec).update is not CandidateSetSpec.update:
+                warnings.warn(
+                    f"{type(self).__name__}.update() called without observations. "
+                    "The candidate set will be built from previously cached data, "
+                    "which may not reflect the current state of the experiment.",
+                    UserWarning,
+                    stacklevel=2,
+                )
             super().update(surrogate, observations)
 
     def _build_botorch_acquisition(self) -> Any:

--- a/src/activelearning/acquisition/botorch/botorch_qbatch.py
+++ b/src/activelearning/acquisition/botorch/botorch_qbatch.py
@@ -1,0 +1,479 @@
+"""Concrete wrappers for BoTorch q-batch (Monte Carlo) acquisition functions.
+
+Each class subclasses :class:`QBatchBoTorchAcquisition` and implements
+:meth:`_build_botorch_acquisition` to construct the corresponding BoTorch
+MC acquisition object.
+"""
+
+import warnings
+from typing import Any, Callable, Iterable, Optional
+
+import torch
+from botorch.acquisition.knowledge_gradient import (
+    qKnowledgeGradient as _qKG,
+)
+from botorch.acquisition.logei import (
+    qLogExpectedImprovement as _qLogEI,
+    qLogNoisyExpectedImprovement as _qLogNEI,
+)
+from botorch.acquisition.max_value_entropy_search import (
+    qMaxValueEntropy as _qMES,
+)
+from botorch.acquisition.monte_carlo import (
+    qExpectedImprovement as _qEI,
+    qNoisyExpectedImprovement as _qNEI,
+    qProbabilityOfImprovement as _qPI,
+    qSimpleRegret as _qSimpleRegret,
+    qUpperConfidenceBound as _qUCB,
+)
+from botorch.acquisition.objective import ScalarizedPosteriorTransform
+
+from activelearning.acquisition.botorch.botorch_acquisition import (
+    BatchScoringMixin,
+    QBatchBoTorchAcquisition,
+)
+from activelearning.acquisition.botorch.candidate_set import CandidateSetSpec
+from activelearning.surrogate.surrogate import Surrogate
+from activelearning.utils.types import Observation
+
+
+class QExpectedImprovement(BatchScoringMixin, QBatchBoTorchAcquisition):
+    """Monte Carlo q-Expected Improvement (qEI).
+
+    Parameters
+    ----------
+    best_f : float, optional
+        Best observed objective value. If ``None``, auto-computed.
+    constraints : list of callables, optional
+        Outcome constraint callables.
+    eta : float, default=1e-3
+        Temperature for the sigmoid approximation of the constraint indicator.
+    **kwargs
+        Forwarded to :class:`QBatchBoTorchAcquisition`.
+    """
+
+    def __init__(
+        self,
+        *,
+        best_f: Optional[float] = None,
+        constraints: Optional[list[Callable[[torch.Tensor], torch.Tensor]]] = None,
+        eta: float = 1e-3,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self._best_f_override = best_f
+        self._constraints = constraints
+        self._eta = eta
+
+    def _build_botorch_acquisition(self) -> Any:
+        """Construct the BoTorch qExpectedImprovement object."""
+        assert self._botorch_surrogate is not None
+        best_f = self._resolve_best_f(self._best_f_override)
+        build_kwargs: dict[str, Any] = {
+            "model": self._botorch_surrogate.get_model(),
+            "best_f": -best_f if not self.maximize else best_f,
+            "constraints": self._constraints,
+            "eta": self._eta,
+        }
+        if not self.maximize:
+            train_X, _ = self._botorch_surrogate.get_train_data()
+            build_kwargs["posterior_transform"] = ScalarizedPosteriorTransform(
+                weights=torch.tensor([-1.0], dtype=train_X.dtype, device=train_X.device)
+            )
+        return _qEI(**build_kwargs)
+
+
+class QLogExpectedImprovement(BatchScoringMixin, QBatchBoTorchAcquisition):
+    """Monte Carlo q-Expected Improvement in log-space for improved numerics.
+
+    Parameters
+    ----------
+    best_f : float, optional
+        Best observed objective value. If ``None``, auto-computed.
+    constraints : list of callables, optional
+        Outcome constraint callables.
+    eta : float, default=1e-3
+        Temperature for the sigmoid approximation of the constraint indicator.
+    **kwargs
+        Forwarded to :class:`QBatchBoTorchAcquisition`.
+    """
+
+    def __init__(
+        self,
+        *,
+        best_f: Optional[float] = None,
+        constraints: Optional[list[Callable[[torch.Tensor], torch.Tensor]]] = None,
+        eta: float = 1e-3,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self._best_f_override = best_f
+        self._constraints = constraints
+        self._eta = eta
+
+    def _build_botorch_acquisition(self) -> Any:
+        """Construct the BoTorch qLogExpectedImprovement object."""
+        assert self._botorch_surrogate is not None
+        best_f = self._resolve_best_f(self._best_f_override)
+        build_kwargs: dict[str, Any] = {
+            "model": self._botorch_surrogate.get_model(),
+            "best_f": -best_f if not self.maximize else best_f,
+            "constraints": self._constraints,
+            "eta": self._eta,
+        }
+        if not self.maximize:
+            train_X, _ = self._botorch_surrogate.get_train_data()
+            build_kwargs["posterior_transform"] = ScalarizedPosteriorTransform(
+                weights=torch.tensor([-1.0], dtype=train_X.dtype, device=train_X.device)
+            )
+        return _qLogEI(**build_kwargs)
+
+
+class QNoisyExpectedImprovement(BatchScoringMixin, QBatchBoTorchAcquisition):
+    """Monte Carlo q-Noisy Expected Improvement (qNEI).
+
+    Uses the training inputs as a baseline rather than requiring an explicit
+    ``best_f`` value, making it more robust in noisy settings.
+
+    Parameters
+    ----------
+    prune_baseline : bool, default=True
+        Whether to prune dominated baseline points.
+    constraints : list of callables, optional
+        Outcome constraint callables.
+    eta : float, default=1e-3
+        Temperature for the sigmoid approximation of the constraint indicator.
+    **kwargs
+        Forwarded to :class:`QBatchBoTorchAcquisition`.
+    """
+
+    def __init__(
+        self,
+        *,
+        prune_baseline: bool = True,
+        constraints: Optional[list[Callable[[torch.Tensor], torch.Tensor]]] = None,
+        eta: float = 1e-3,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self._prune_baseline = prune_baseline
+        self._constraints = constraints
+        self._eta = eta
+
+    def _build_botorch_acquisition(self) -> Any:
+        """Construct the BoTorch qNoisyExpectedImprovement object."""
+        assert self._botorch_surrogate is not None
+        train_X, _ = self._botorch_surrogate.get_train_data()
+        build_kwargs: dict[str, Any] = {
+            "model": self._botorch_surrogate.get_model(),
+            "X_baseline": train_X,
+            "prune_baseline": self._prune_baseline,
+            "constraints": self._constraints,
+            "eta": self._eta,
+        }
+        if not self.maximize:
+            build_kwargs["posterior_transform"] = ScalarizedPosteriorTransform(
+                weights=torch.tensor([-1.0], dtype=train_X.dtype, device=train_X.device)
+            )
+        return _qNEI(**build_kwargs)
+
+
+class QLogNoisyExpectedImprovement(BatchScoringMixin, QBatchBoTorchAcquisition):
+    """Monte Carlo q-Noisy Expected Improvement in log-space.
+
+    Parameters
+    ----------
+    prune_baseline : bool, default=True
+        Whether to prune dominated baseline points.
+    constraints : list of callables, optional
+        Outcome constraint callables.
+    eta : float, default=1e-3
+        Temperature for the sigmoid approximation of the constraint indicator.
+    **kwargs
+        Forwarded to :class:`QBatchBoTorchAcquisition`.
+    """
+
+    def __init__(
+        self,
+        *,
+        prune_baseline: bool = True,
+        constraints: Optional[list[Callable[[torch.Tensor], torch.Tensor]]] = None,
+        eta: float = 1e-3,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self._prune_baseline = prune_baseline
+        self._constraints = constraints
+        self._eta = eta
+
+    def _build_botorch_acquisition(self) -> Any:
+        """Construct the BoTorch qLogNoisyExpectedImprovement object."""
+        assert self._botorch_surrogate is not None
+        train_X, _ = self._botorch_surrogate.get_train_data()
+        build_kwargs: dict[str, Any] = {
+            "model": self._botorch_surrogate.get_model(),
+            "X_baseline": train_X,
+            "prune_baseline": self._prune_baseline,
+            "constraints": self._constraints,
+            "eta": self._eta,
+        }
+        if not self.maximize:
+            build_kwargs["posterior_transform"] = ScalarizedPosteriorTransform(
+                weights=torch.tensor([-1.0], dtype=train_X.dtype, device=train_X.device)
+            )
+        return _qLogNEI(**build_kwargs)
+
+
+class QUpperConfidenceBound(BatchScoringMixin, QBatchBoTorchAcquisition):
+    """Monte Carlo q-Upper Confidence Bound (qUCB).
+
+    Parameters
+    ----------
+    beta : float, default=2.0
+        Exploration weight.
+    **kwargs
+        Forwarded to :class:`QBatchBoTorchAcquisition`.
+    """
+
+    def __init__(self, *, beta: float = 2.0, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._beta = beta
+
+    def _build_botorch_acquisition(self) -> Any:
+        """Construct the BoTorch qUpperConfidenceBound object."""
+        assert self._botorch_surrogate is not None
+        build_kwargs: dict[str, Any] = {
+            "model": self._botorch_surrogate.get_model(),
+            "beta": self._beta,
+        }
+        if not self.maximize:
+            train_X, _ = self._botorch_surrogate.get_train_data()
+            build_kwargs["posterior_transform"] = ScalarizedPosteriorTransform(
+                weights=torch.tensor([-1.0], dtype=train_X.dtype, device=train_X.device)
+            )
+        return _qUCB(**build_kwargs)
+
+
+class QProbabilityOfImprovement(BatchScoringMixin, QBatchBoTorchAcquisition):
+    """Monte Carlo q-Probability of Improvement (qPI).
+
+    Parameters
+    ----------
+    best_f : float, optional
+        Best observed objective value. If ``None``, auto-computed.
+    constraints : list of callables, optional
+        Outcome constraint callables.
+    eta : float, default=1e-3
+        Temperature for the sigmoid approximation of the constraint indicator.
+    tau : float, default=1e-3
+        Temperature for the sigmoid approximation of the improvement indicator.
+    **kwargs
+        Forwarded to :class:`QBatchBoTorchAcquisition`.
+    """
+
+    def __init__(
+        self,
+        *,
+        best_f: Optional[float] = None,
+        constraints: Optional[list[Callable[[torch.Tensor], torch.Tensor]]] = None,
+        eta: float = 1e-3,
+        tau: float = 1e-3,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self._best_f_override = best_f
+        self._constraints = constraints
+        self._eta = eta
+        self._tau = tau
+
+    def _build_botorch_acquisition(self) -> Any:
+        """Construct the BoTorch qProbabilityOfImprovement object."""
+        assert self._botorch_surrogate is not None
+        best_f = self._resolve_best_f(self._best_f_override)
+        build_kwargs: dict[str, Any] = {
+            "model": self._botorch_surrogate.get_model(),
+            "best_f": -best_f if not self.maximize else best_f,
+            "constraints": self._constraints,
+            "eta": self._eta,
+            "tau": self._tau,
+        }
+        if not self.maximize:
+            train_X, _ = self._botorch_surrogate.get_train_data()
+            build_kwargs["posterior_transform"] = ScalarizedPosteriorTransform(
+                weights=torch.tensor([-1.0], dtype=train_X.dtype, device=train_X.device)
+            )
+        return _qPI(**build_kwargs)
+
+
+class QSimpleRegret(BatchScoringMixin, QBatchBoTorchAcquisition):
+    """Monte Carlo q-Simple Regret.
+
+    Parameters
+    ----------
+    **kwargs
+        Forwarded to :class:`QBatchBoTorchAcquisition`.
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+
+    def _build_botorch_acquisition(self) -> Any:
+        """Construct the BoTorch qSimpleRegret object."""
+        assert self._botorch_surrogate is not None
+        build_kwargs: dict[str, Any] = {
+            "model": self._botorch_surrogate.get_model(),
+        }
+        if not self.maximize:
+            train_X, _ = self._botorch_surrogate.get_train_data()
+            build_kwargs["posterior_transform"] = ScalarizedPosteriorTransform(
+                weights=torch.tensor([-1.0], dtype=train_X.dtype, device=train_X.device)
+            )
+        return _qSimpleRegret(**build_kwargs)
+
+
+class QKnowledgeGradient(QBatchBoTorchAcquisition):
+    """Monte Carlo q-Knowledge Gradient (qKG).
+
+    Parameters
+    ----------
+    num_fantasies : int, default=64
+        Number of fantasy models used for inner optimization.
+    current_value : float, optional
+        Current best objective value. If ``None``, BoTorch estimates it.
+    **kwargs
+        Forwarded to :class:`QBatchBoTorchAcquisition`.
+    """
+
+    def __init__(
+        self,
+        *,
+        num_fantasies: int = 64,
+        current_value: Optional[float] = None,
+        **kwargs: Any,
+    ) -> None:
+        if num_fantasies <= 0:
+            raise ValueError(f"num_fantasies must be > 0, got {num_fantasies}")
+        super().__init__(**kwargs)
+        self._num_fantasies = num_fantasies
+        self._current_value = current_value
+
+    def _build_botorch_acquisition(self) -> Any:
+        """Construct the BoTorch qKnowledgeGradient object."""
+        assert self._botorch_surrogate is not None
+        train_X, _ = self._botorch_surrogate.get_train_data()
+
+        # qKG internally uses fantasy models, which require GPyTorch's
+        # prediction_strategy to be initialized. This happens on the first
+        # posterior evaluation in eval mode.
+        model = self._botorch_surrogate.get_model()
+        model.eval()
+        with torch.no_grad():
+            model.posterior(train_X)
+
+        current_value = None
+        if self._current_value is not None:
+            # When maximize=False the posterior_transform negates the objective,
+            # so current_value must also be negated to stay in the same space.
+            raw = -self._current_value if not self.maximize else self._current_value
+            current_value = torch.tensor(
+                raw, dtype=train_X.dtype, device=train_X.device
+            )
+
+        build_kwargs: dict[str, Any] = {
+            "model": model,
+            "num_fantasies": self._num_fantasies,
+            "current_value": current_value,
+        }
+        if not self.maximize:
+            build_kwargs["posterior_transform"] = ScalarizedPosteriorTransform(
+                weights=torch.tensor([-1.0], dtype=train_X.dtype, device=train_X.device)
+            )
+        return _qKG(**build_kwargs)
+
+
+class QMaxValueEntropy(QBatchBoTorchAcquisition):
+    """Monte Carlo q-Max-Value Entropy Search (qMES).
+
+    Parameters
+    ----------
+    candidate_set_spec : CandidateSetSpec
+        Specification describing how to build the discrete candidate set used
+        to approximate the max-value distribution.
+    num_fantasies : int, default=16
+        Number of fantasy models used to approximate the joint entropy.
+    num_mv_samples : int, default=10
+        Number of samples drawn to approximate the max-value distribution.
+    num_y_samples : int, default=128
+        Number of outcome samples drawn per max-value sample.
+    **kwargs
+        Forwarded to :class:`QBatchBoTorchAcquisition`.
+    """
+
+    def __init__(
+        self,
+        *,
+        candidate_set_spec: CandidateSetSpec,
+        num_fantasies: int = 16,
+        num_mv_samples: int = 10,
+        num_y_samples: int = 128,
+        **kwargs: Any,
+    ) -> None:
+        if num_fantasies <= 0:
+            raise ValueError(f"num_fantasies must be > 0, got {num_fantasies}")
+        if num_mv_samples <= 0:
+            raise ValueError(f"num_mv_samples must be > 0, got {num_mv_samples}")
+        if num_y_samples <= 0:
+            raise ValueError(f"num_y_samples must be > 0, got {num_y_samples}")
+        super().__init__(**kwargs)
+        self._candidate_set_spec = candidate_set_spec
+        self._num_fantasies = num_fantasies
+        self._num_mv_samples = num_mv_samples
+        self._num_y_samples = num_y_samples
+
+    def update(
+        self,
+        surrogate: Surrogate,
+        observations: Optional[Iterable[Observation]] = None,
+    ) -> None:
+        """Update the candidate set spec with current observations, then update the base.
+
+        The candidate set (used to approximate the max-value distribution) is
+        refreshed each round from the latest observations before the BoTorch
+        acquisition object is rebuilt.
+
+        Parameters
+        ----------
+        surrogate : Surrogate
+            The fitted surrogate model for the current round.
+        observations : Iterable[Observation], optional
+            Current observations forwarded to the candidate set spec and base.
+        """
+        if observations is not None:
+            obs_list = list(observations)
+            self._candidate_set_spec.update(obs_list)
+            super().update(surrogate, obs_list)
+        else:
+            if type(self._candidate_set_spec).update is not CandidateSetSpec.update:
+                warnings.warn(
+                    f"{type(self).__name__}.update() called without observations. "
+                    "The candidate set will be built from previously cached data, "
+                    "which may not reflect the current state of the experiment.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            super().update(surrogate, observations)
+
+    def _build_botorch_acquisition(self) -> Any:
+        """Construct the BoTorch qMaxValueEntropy object."""
+        if self._botorch_surrogate is None:
+            raise RuntimeError(
+                f"{self.__class__.__name__} not updated with surrogate before building acquisition."
+            )
+        return _qMES(
+            model=self._botorch_surrogate.get_model(),
+            candidate_set=self._candidate_set_spec.build(self._botorch_surrogate),
+            num_fantasies=self._num_fantasies,
+            num_mv_samples=self._num_mv_samples,
+            num_y_samples=self._num_y_samples,
+            maximize=self.maximize,
+        )

--- a/src/activelearning/surrogate/botorch_surrogate.py
+++ b/src/activelearning/surrogate/botorch_surrogate.py
@@ -398,7 +398,7 @@ class BoTorchGPSurrogate(Surrogate):
         ValueError
             If candidates are incompatible with the fitted model mode.
         """
-        cand_list = list(candidates)
+        cand_list = candidates if isinstance(candidates, list) else list(candidates)
         if not cand_list:
             raise ValueError("Cannot encode an empty candidate iterable.")
 
@@ -478,7 +478,10 @@ class BoTorchGPSurrogate(Surrogate):
             If no batches are provided, if batch sizes are ragged, or if any
             batch is incompatible with the fitted model.
         """
-        batch_list = [list(batch) for batch in candidate_batches]
+        batch_list = [
+            batch if isinstance(batch, list) else list(batch)
+            for batch in candidate_batches
+        ]
         if not batch_list:
             raise ValueError("Cannot encode an empty batch iterable.")
         if any(len(batch) == 0 for batch in batch_list):

--- a/tests/acquisition/test_botorch_acquisition.py
+++ b/tests/acquisition/test_botorch_acquisition.py
@@ -10,6 +10,7 @@ import torch
 
 from activelearning.acquisition.botorch.botorch_acquisition import (
     AnalyticBoTorchAcquisition,
+    BatchScoringMixin,
     QBatchBoTorchAcquisition,
 )
 from activelearning.acquisition.botorch.candidate_set import TrainDataCandidateSetSpec
@@ -37,7 +38,7 @@ class StubAnalytic(AnalyticBoTorchAcquisition):
         return lambda X: X.squeeze(-2).sum(dim=-1)
 
 
-class StubQBatch(QBatchBoTorchAcquisition):
+class StubQBatch(BatchScoringMixin, QBatchBoTorchAcquisition):
     """Q-batch stub that wraps a callable as the BoTorch acquisition function."""
 
     def __init__(self, acqf_fn: Optional[Any] = None, **kwargs: Any) -> None:
@@ -123,7 +124,7 @@ class TestCapabilityFlags:
     def test_qbatch_flags(self) -> None:
         acq = StubQBatch()
         assert acq.supports_singleton_scoring is True
-        assert acq.supports_batch_scoring is False
+        assert acq.supports_batch_scoring is True
 
     def test_maximize_default(self) -> None:
         assert StubAnalytic().maximize is True
@@ -206,6 +207,51 @@ class TestParameterValidation:
             QMultiFidelityMaxValueEntropy(
                 candidate_set_spec=spec,
                 num_y_samples=0,
+            )
+
+    def test_qkg_num_fantasies_must_be_positive(self) -> None:
+        """QKnowledgeGradient.num_fantasies must be > 0."""
+        from activelearning.acquisition.botorch.botorch_qbatch import (
+            QKnowledgeGradient,
+        )
+
+        with pytest.raises(ValueError, match="num_fantasies must be > 0"):
+            QKnowledgeGradient(num_fantasies=0)
+
+    def test_qmes_num_fantasies_must_be_positive(self) -> None:
+        """QMaxValueEntropy.num_fantasies must be > 0."""
+        from activelearning.acquisition.botorch.botorch_qbatch import QMaxValueEntropy
+        from activelearning.acquisition.botorch.candidate_set import (
+            TrainDataCandidateSetSpec,
+        )
+
+        with pytest.raises(ValueError, match="num_fantasies must be > 0"):
+            QMaxValueEntropy(
+                candidate_set_spec=TrainDataCandidateSetSpec(), num_fantasies=0
+            )
+
+    def test_qmes_num_mv_samples_must_be_positive(self) -> None:
+        """QMaxValueEntropy.num_mv_samples must be > 0."""
+        from activelearning.acquisition.botorch.botorch_qbatch import QMaxValueEntropy
+        from activelearning.acquisition.botorch.candidate_set import (
+            TrainDataCandidateSetSpec,
+        )
+
+        with pytest.raises(ValueError, match="num_mv_samples must be > 0"):
+            QMaxValueEntropy(
+                candidate_set_spec=TrainDataCandidateSetSpec(), num_mv_samples=0
+            )
+
+    def test_qmes_num_y_samples_must_be_positive(self) -> None:
+        """QMaxValueEntropy.num_y_samples must be > 0."""
+        from activelearning.acquisition.botorch.botorch_qbatch import QMaxValueEntropy
+        from activelearning.acquisition.botorch.candidate_set import (
+            TrainDataCandidateSetSpec,
+        )
+
+        with pytest.raises(ValueError, match="num_y_samples must be > 0"):
+            QMaxValueEntropy(
+                candidate_set_spec=TrainDataCandidateSetSpec(), num_y_samples=0
             )
 
 
@@ -525,6 +571,63 @@ class TestQBatchScore:
         acq.update(fitted_surrogate, single_fidelity_observations)
         scores = acq.score([])
         assert scores == []
+
+    def test_empty_batch_list_returns_empty(
+        self,
+        fitted_surrogate: BoTorchGPSurrogate,
+        single_fidelity_observations: list[Observation],
+    ) -> None:
+        """score_batches([]) should return [] to match score([]) behaviour."""
+        acq = StubQBatch()
+        acq.update(fitted_surrogate, single_fidelity_observations)
+        scores = acq.score_batches([])
+        assert scores == []
+
+    def test_batch_returns_ones_before_update(
+        self, candidate_batches: list[list[Candidate]]
+    ) -> None:
+        """Before update(), score_batches() returns constant 1.0 for every batch."""
+        acq = StubQBatch()
+        scores = acq.score_batches(candidate_batches)
+        assert scores == [1.0] * len(candidate_batches)
+
+    def test_batch_returns_one_score_per_batch(
+        self,
+        fitted_surrogate: BoTorchGPSurrogate,
+        single_fidelity_observations: list[Observation],
+        candidate_batches: list[list[Candidate]],
+    ) -> None:
+        """After update(), score_batches() returns one float per batch."""
+        acq = StubQBatch()
+        acq.update(fitted_surrogate, single_fidelity_observations)
+        scores = acq.score_batches(candidate_batches)
+        assert len(scores) == len(candidate_batches)
+        assert all(isinstance(s, float) for s in scores)
+
+    def test_batch_cost_weighting_applied_after_update(
+        self,
+        fitted_surrogate: BoTorchGPSurrogate,
+        single_fidelity_observations: list[Observation],
+        candidate_batches: list[list[Candidate]],
+    ) -> None:
+        """cost_weighting post-processes batch scores after update()."""
+        acq = StubQBatch()
+        acq.update(fitted_surrogate, single_fidelity_observations)
+        raw_scores = acq.score_batches(candidate_batches)
+        cost_weighting = lambda scores, batches: [s / 2.0 for s in scores]  # noqa: E731
+        weighted = acq.score_batches(candidate_batches, cost_weighting=cost_weighting)
+        assert len(weighted) == len(raw_scores)
+        for raw, ws in zip(raw_scores, weighted):
+            assert math.isclose(ws, raw / 2.0, rel_tol=1e-6)
+
+    def test_batch_cost_weighting_not_applied_before_update(
+        self, candidate_batches: list[list[Candidate]]
+    ) -> None:
+        """cost_weighting has no effect before update() — all batch scores remain 1.0."""
+        acq = StubQBatch()
+        cost_weighting = lambda scores, batches: [s * 999 for s in scores]  # noqa: E731
+        scores = acq.score_batches(candidate_batches, cost_weighting=cost_weighting)
+        assert scores == [1.0] * len(candidate_batches)
 
 
 # ===================================================================
@@ -1092,3 +1195,336 @@ class TestMultiFidelityAcquisitionIntegration:
         scores_min = acq_min.score(mf_cands)
 
         assert scores_max != scores_min
+
+    def test_qmfmes_stale_cache_warning(
+        self,
+        mf_surrogate: BoTorchGPSurrogate,
+        mf_obs: list[Observation],
+        train_data_spec: TrainDataCandidateSetSpec,
+    ) -> None:
+        """Calling update() without observations after a prior round warns about stale cache."""
+        from activelearning.acquisition.botorch.botorch_multifidelity import (
+            QMultiFidelityMaxValueEntropy,
+        )
+
+        acq = QMultiFidelityMaxValueEntropy(
+            candidate_set_spec=train_data_spec,
+            num_fantasies=2,
+            num_mv_samples=5,
+            num_y_samples=16,
+        )
+        acq.update(mf_surrogate, mf_obs)
+
+        with pytest.warns(UserWarning, match="called without observations"):
+            acq.update(mf_surrogate, None)
+
+
+# ===================================================================
+# Concrete qbatch acquisition integration tests
+# ===================================================================
+
+
+class TestQBatchAcquisitionIntegration:
+    """Integration tests for concrete qbatch acquisition wrappers.
+
+    Verifies that each class can be updated with a fitted surrogate and
+    produces valid float scores, and that constructor parameters are
+    correctly forwarded to BoTorch.
+    """
+
+    @pytest.fixture()
+    def sf_obs(self) -> list[Observation]:
+        return [
+            Observation(x=[1.0, 2.0], y=5.0),
+            Observation(x=[3.0, 4.0], y=7.0),
+            Observation(x=[5.0, 6.0], y=9.0),
+        ]
+
+    @pytest.fixture()
+    def sf_surrogate(self, sf_obs: list[Observation]) -> BoTorchGPSurrogate:
+        s = BoTorchGPSurrogate()
+        s.fit(sf_obs)
+        return s
+
+    @pytest.fixture()
+    def cands(self) -> list[Candidate]:
+        return [Candidate(x=[2.0, 3.0]), Candidate(x=[4.0, 5.0])]
+
+    def _scores_valid(self, scores: list[float], n: int = 2) -> None:
+        assert len(scores) == n
+        assert all(isinstance(s, float) for s in scores)
+        assert all(math.isfinite(s) for s in scores)
+
+    def test_qmes_scores(
+        self,
+        sf_surrogate: BoTorchGPSurrogate,
+        sf_obs: list[Observation],
+        cands: list[Candidate],
+    ) -> None:
+        from activelearning.acquisition.botorch.botorch_qbatch import QMaxValueEntropy
+        from activelearning.acquisition.botorch.candidate_set import (
+            TrainDataCandidateSetSpec,
+        )
+
+        acq = QMaxValueEntropy(
+            candidate_set_spec=TrainDataCandidateSetSpec(),
+            num_fantasies=2,
+            num_mv_samples=5,
+            num_y_samples=16,
+        )
+        acq.update(sf_surrogate, sf_obs)
+        self._scores_valid(acq.score(cands))
+
+    def test_qmes_maximize_false_differs_from_maximize_true(
+        self,
+        sf_surrogate: BoTorchGPSurrogate,
+        sf_obs: list[Observation],
+        cands: list[Candidate],
+    ) -> None:
+        """maximize=False should produce different scores than maximize=True."""
+        from activelearning.acquisition.botorch.botorch_qbatch import QMaxValueEntropy
+        from activelearning.acquisition.botorch.candidate_set import (
+            TrainDataCandidateSetSpec,
+        )
+
+        acq_max = QMaxValueEntropy(
+            candidate_set_spec=TrainDataCandidateSetSpec(),
+            num_fantasies=2,
+            num_mv_samples=5,
+            num_y_samples=16,
+            maximize=True,
+        )
+        acq_max.update(sf_surrogate, sf_obs)
+        scores_max = acq_max.score(cands)
+
+        acq_min = QMaxValueEntropy(
+            candidate_set_spec=TrainDataCandidateSetSpec(),
+            num_fantasies=2,
+            num_mv_samples=5,
+            num_y_samples=16,
+            maximize=False,
+        )
+        acq_min.update(sf_surrogate, sf_obs)
+        scores_min = acq_min.score(cands)
+
+        assert scores_max != scores_min
+
+    def test_qei_scores(
+        self,
+        sf_surrogate: BoTorchGPSurrogate,
+        sf_obs: list[Observation],
+        cands: list[Candidate],
+    ) -> None:
+        from activelearning.acquisition.botorch.botorch_qbatch import (
+            QExpectedImprovement,
+        )
+
+        acq = QExpectedImprovement()
+        acq.update(sf_surrogate, sf_obs)
+        self._scores_valid(acq.score(cands))
+
+    def test_qei_maximize_false(
+        self,
+        sf_surrogate: BoTorchGPSurrogate,
+        sf_obs: list[Observation],
+        cands: list[Candidate],
+    ) -> None:
+        """maximize=False should produce different scores than maximize=True."""
+        from activelearning.acquisition.botorch.botorch_qbatch import (
+            QExpectedImprovement,
+        )
+
+        torch.manual_seed(0)
+        acq_max = QExpectedImprovement(maximize=True)
+        acq_max.update(sf_surrogate, sf_obs)
+        scores_max = acq_max.score(cands)
+
+        torch.manual_seed(0)
+        acq_min = QExpectedImprovement(maximize=False)
+        acq_min.update(sf_surrogate, sf_obs)
+        scores_min = acq_min.score(cands)
+
+        assert scores_max != scores_min
+
+    def test_qlogei_scores(
+        self,
+        sf_surrogate: BoTorchGPSurrogate,
+        sf_obs: list[Observation],
+        cands: list[Candidate],
+    ) -> None:
+        from activelearning.acquisition.botorch.botorch_qbatch import (
+            QLogExpectedImprovement,
+        )
+
+        acq = QLogExpectedImprovement()
+        acq.update(sf_surrogate, sf_obs)
+        self._scores_valid(acq.score(cands))
+
+    def test_qnei_scores(
+        self,
+        sf_surrogate: BoTorchGPSurrogate,
+        sf_obs: list[Observation],
+        cands: list[Candidate],
+    ) -> None:
+        from activelearning.acquisition.botorch.botorch_qbatch import (
+            QNoisyExpectedImprovement,
+        )
+
+        acq = QNoisyExpectedImprovement()
+        acq.update(sf_surrogate, sf_obs)
+        self._scores_valid(acq.score(cands))
+
+    def test_qnei_maximize_false(
+        self,
+        sf_surrogate: BoTorchGPSurrogate,
+        sf_obs: list[Observation],
+        cands: list[Candidate],
+    ) -> None:
+        """maximize=False should produce different scores than maximize=True."""
+        from activelearning.acquisition.botorch.botorch_qbatch import (
+            QNoisyExpectedImprovement,
+        )
+
+        torch.manual_seed(0)
+        acq_max = QNoisyExpectedImprovement(maximize=True)
+        acq_max.update(sf_surrogate, sf_obs)
+        scores_max = acq_max.score(cands)
+
+        torch.manual_seed(0)
+        acq_min = QNoisyExpectedImprovement(maximize=False)
+        acq_min.update(sf_surrogate, sf_obs)
+        scores_min = acq_min.score(cands)
+
+        assert scores_max != scores_min
+
+    def test_qlognei_scores(
+        self,
+        sf_surrogate: BoTorchGPSurrogate,
+        sf_obs: list[Observation],
+        cands: list[Candidate],
+    ) -> None:
+        from activelearning.acquisition.botorch.botorch_qbatch import (
+            QLogNoisyExpectedImprovement,
+        )
+
+        acq = QLogNoisyExpectedImprovement()
+        acq.update(sf_surrogate, sf_obs)
+        self._scores_valid(acq.score(cands))
+
+    def test_qucb_scores(
+        self,
+        sf_surrogate: BoTorchGPSurrogate,
+        sf_obs: list[Observation],
+        cands: list[Candidate],
+    ) -> None:
+        from activelearning.acquisition.botorch.botorch_qbatch import (
+            QUpperConfidenceBound,
+        )
+
+        acq = QUpperConfidenceBound(beta=2.0)
+        acq.update(sf_surrogate, sf_obs)
+        self._scores_valid(acq.score(cands))
+
+    def test_qucb_maximize_false(
+        self,
+        sf_surrogate: BoTorchGPSurrogate,
+        sf_obs: list[Observation],
+        cands: list[Candidate],
+    ) -> None:
+        """maximize=False should produce different scores than maximize=True."""
+        from activelearning.acquisition.botorch.botorch_qbatch import (
+            QUpperConfidenceBound,
+        )
+
+        torch.manual_seed(0)
+        acq_max = QUpperConfidenceBound(beta=2.0, maximize=True)
+        acq_max.update(sf_surrogate, sf_obs)
+        scores_max = acq_max.score(cands)
+
+        torch.manual_seed(0)
+        acq_min = QUpperConfidenceBound(beta=2.0, maximize=False)
+        acq_min.update(sf_surrogate, sf_obs)
+        scores_min = acq_min.score(cands)
+
+        assert scores_max != scores_min
+
+    def test_qpi_scores(
+        self,
+        sf_surrogate: BoTorchGPSurrogate,
+        sf_obs: list[Observation],
+        cands: list[Candidate],
+    ) -> None:
+        from activelearning.acquisition.botorch.botorch_qbatch import (
+            QProbabilityOfImprovement,
+        )
+
+        acq = QProbabilityOfImprovement()
+        acq.update(sf_surrogate, sf_obs)
+        self._scores_valid(acq.score(cands))
+
+    def test_qsr_scores(
+        self,
+        sf_surrogate: BoTorchGPSurrogate,
+        sf_obs: list[Observation],
+        cands: list[Candidate],
+    ) -> None:
+        from activelearning.acquisition.botorch.botorch_qbatch import QSimpleRegret
+
+        acq = QSimpleRegret()
+        acq.update(sf_surrogate, sf_obs)
+        self._scores_valid(acq.score(cands))
+
+    def test_qsr_maximize_false(
+        self,
+        sf_surrogate: BoTorchGPSurrogate,
+        sf_obs: list[Observation],
+        cands: list[Candidate],
+    ) -> None:
+        """maximize=False should produce different scores than maximize=True."""
+        from activelearning.acquisition.botorch.botorch_qbatch import QSimpleRegret
+
+        torch.manual_seed(0)
+        acq_max = QSimpleRegret(maximize=True)
+        acq_max.update(sf_surrogate, sf_obs)
+        scores_max = acq_max.score(cands)
+
+        torch.manual_seed(0)
+        acq_min = QSimpleRegret(maximize=False)
+        acq_min.update(sf_surrogate, sf_obs)
+        scores_min = acq_min.score(cands)
+
+        assert scores_max != scores_min
+
+    def test_qkg_scores(
+        self,
+        sf_surrogate: BoTorchGPSurrogate,
+        sf_obs: list[Observation],
+        cands: list[Candidate],
+    ) -> None:
+        from activelearning.acquisition.botorch.botorch_qbatch import QKnowledgeGradient
+
+        acq = QKnowledgeGradient(num_fantasies=1)
+        acq.update(sf_surrogate, sf_obs)
+        self._scores_valid(acq.score(cands))
+
+    def test_qmes_stale_cache_warning(
+        self,
+        sf_surrogate: BoTorchGPSurrogate,
+        sf_obs: list[Observation],
+    ) -> None:
+        """Calling update() without observations after a prior round warns about stale cache."""
+        from activelearning.acquisition.botorch.botorch_qbatch import QMaxValueEntropy
+        from activelearning.acquisition.botorch.candidate_set import (
+            TrainDataCandidateSetSpec,
+        )
+
+        acq = QMaxValueEntropy(
+            candidate_set_spec=TrainDataCandidateSetSpec(),
+            num_fantasies=2,
+            num_mv_samples=5,
+            num_y_samples=16,
+        )
+        acq.update(sf_surrogate, sf_obs)
+
+        with pytest.warns(UserWarning, match="called without observations"):
+            acq.update(sf_surrogate, None)


### PR DESCRIPTION
# PR: q-batch acquisition functions and batch scoring

**Base branch:** `features/acquisition-api-and-botorch`  
**Head branch:** `features/qbatch-acquisitions`

---

## Summary

Extends the BoTorch acquisition layer introduced in the previous PR with nine
Monte Carlo (q-batch) acquisition functions and opt-in joint batch scoring.
This enables callers to evaluate a *set* of candidates jointly — the natural
mode for most BoTorch MC acquisitions — rather than independently.

---

## Changes

### `BatchScoringMixin` (`botorch_acquisition.py`)

A lightweight mixin that adds `score_batches()` to any q-batch acquisition
that supports joint evaluation:

```python
class QExpectedImprovement(BatchScoringMixin, QBatchBoTorchAcquisition):
    ...
```

- `score_batches(candidate_batches, cost_weighting=None) → list[float]`
  encodes each batch as a `(q, d)` tensor and passes them as a single
  t-batched forward call `(B, q, d)`.
- Returns `[1.0] * B` before `update()` is called (consistent with
  `score()` behaviour on first round).
- `cost_weighting` post-processing follows the same pattern as `score()`.
- Acquisitions that do **not** mix in `BatchScoringMixin` retain
  `supports_batch_scoring = False` and raise `NotImplementedError` on
  `score_batches()` — explicit rather than silent.

### New file: `botorch_qbatch.py`

Eight concrete q-batch acquisition wrappers plus `QMaxValueEntropy`:

| Class | BoTorch backing | Batch scoring |
|---|---|---|
| `QExpectedImprovement` | `qExpectedImprovement` | ✅ |
| `QLogExpectedImprovement` | `qLogExpectedImprovement` | ✅ |
| `QNoisyExpectedImprovement` | `qNoisyExpectedImprovement` | ✅ |
| `QLogNoisyExpectedImprovement` | `qLogNoisyExpectedImprovement` | ✅ |
| `QUpperConfidenceBound` | `qUpperConfidenceBound` | ✅ |
| `QProbabilityOfImprovement` | `qProbabilityOfImprovement` | ✅ |
| `QSimpleRegret` | `qSimpleRegret` | ✅ |
| `QKnowledgeGradient` | `qKnowledgeGradient` | ❌ |
| `QMaxValueEntropy` | `qMaxValueEntropy` | ❌ |

Not all q-batch acquisitions support joint scoring. Some (such as
`QKnowledgeGradient` and `QMaxValueEntropy`) use one-shot or fantasy-based
optimisation internally, where jointly evaluating a pre-formed batch of
candidates does not produce meaningful scores. These omit `BatchScoringMixin`
and should be used via singleton `score()` instead.

### Minimisation support (`maximize=False`)

BoTorch MC acquisitions with the exception of qMES do not accept a `maximize` parameter directly (unlike
their analytic counterparts). When `maximize=False`, each wrapper applies a
`ScalarizedPosteriorTransform(weights=[-1])` to negate the posterior, and
reference values (`best_f`, `current_value`) are negated accordingly. This
ensures correct behaviour for minimisation objectives across all nine wrappers.

### Stale candidate-set warning

Entropy-based acquisitions that depend on a `CandidateSetSpec` (e.g.
`QMaxValueEntropy`) now emit a `UserWarning` when `update()` is called
without observations, alerting users that the candidate set may be stale.
The warning is scoped to specs that override `CandidateSetSpec.update()`,
so stateless specs like `HypercubeCandidateSetSpec` are not affected.

### Surrogate encoding optimisation

`encode_candidates()` and `encode_candidate_batches()` skip redundant
`list()` copies when the input is already materialised, avoiding
unnecessary allocations in the `score_batches()` path.

### Validation added

- `QKnowledgeGradient.__init__` raises `ValueError` if `num_fantasies <= 0`.
- `QMaxValueEntropy.__init__` raises `ValueError` if `num_fantasies`, `num_mv_samples`, or `num_y_samples` ≤ 0.

---

## Design decisions

**Why a mixin rather than a base class flag?**  
Joint batch scoring is an *opt-in capability*, not a default. Inheriting from
`BatchScoringMixin` is explicit at the class definition site and makes it
immediately clear which acquisitions support it. A boolean flag would require
reading the implementation to know whether `score_batches` is safe to call.

**Why `ScalarizedPosteriorTransform` for minimisation?**  
BoTorch's analytic acquisitions accept `maximize=True/False`, but the MC
variants do not. Negating the posterior via a `ScalarizedPosteriorTransform`
is the standard BoTorch pattern for minimisation in the MC setting. Reference
values (`best_f`, `current_value`) are negated to stay consistent with the
flipped objective space.

---

## Testing

- Integration tests for all nine acquisitions covering: surrogate update,
  valid float scores, constructor parameter forwarding.
- `maximize=False` tests for qEI, qNEI, qUCB, and qSR verifying
  scores differ from `maximize=True`.
- `BatchScoringMixin` tests: joint scoring after update, `cost_weighting`
  application, empty input handling, pre-update fallback to `1.0`.
- Stale candidate-set warning tests for both `QMaxValueEntropy` and
  `QMultiFidelityMaxValueEntropy`.
- Validation tests: `num_fantasies`/`num_mv_samples`/`num_y_samples` ≤ 0 raises `ValueError`.

**409 tests passing.**
