### PR TITLE
Features/pending aware selector

### DIFF
--- a/src/activelearning/acquisition/botorch/botorch_acquisition.py
+++ b/src/activelearning/acquisition/botorch/botorch_acquisition.py
@@ -358,6 +358,117 @@ class BoTorchAcquisitionBase(Acquisition, ABC):
             return raw_scores
         return cost_weighting(raw_scores, cand_list)
 
+    @property
+    def supports_pending_scoring(self) -> bool:
+        """Whether this acquisition supports pending-aware singleton scoring.
+
+        Always ``True`` for BoTorch acquisitions: all BoTorch acquisition
+        functions expose ``set_X_pending()``, which is used by
+        :meth:`score_with_pending` to condition on already-selected candidates
+        without rebuilding the acquisition object.
+        """
+        return True
+
+    def score_with_pending(
+        self,
+        candidates: Iterable[Candidate],
+        pending_candidates: Iterable[Candidate],
+        cost_weighting: Optional[
+            Callable[[list[float], list[Candidate]], list[float]]
+        ] = None,
+    ) -> list[float]:
+        """Score candidates conditioned on a set of pending (already-selected) candidates.
+
+        Intended for pending-aware greedy batch construction: at each step the
+        already-selected candidates are passed as ``pending_candidates`` so the
+        acquisition accounts for their expected information gain before scoring
+        the remainder.
+
+        Internally this calls ``set_X_pending(X_pending)`` on the live BoTorch
+        acquisition object, where ``X_pending`` has shape ``(P, d)`` — the full
+        model-space dimensionality including the fidelity column in multi-fidelity
+        mode. For each candidate ``X`` with shape ``(N, 1, d)``, BoTorch
+        broadcasts the pending tensor and evaluates a q-batch of size ``1 + P``,
+        so each score reflects the marginal value of the candidate *given* the
+        pending observations.
+
+        The pending state is always restored to its previous value via
+        ``try/finally``, so the stored acquisition is left unchanged after the
+        call, regardless of whether scoring raises.
+
+        Falls back to :meth:`score` when ``pending_candidates`` is empty.
+        Returns a constant score of ``1.0`` for every candidate when the
+        acquisition has not yet been coupled to a fitted surrogate, consistent
+        with :meth:`score` behaviour on the first round.
+
+        .. warning::
+            **Entropy-search acquisitions (qMES, qMFMES)** override
+            ``set_X_pending`` to fit a full fantasy GP on the pending points.
+            Each call to this method therefore triggers a GP fantasization step,
+            which can be expensive when selecting large batches with a greedy
+            loop. For cheaper acquisitions (qEI, qNEI, qKG, qUCB, etc.),
+            ``set_X_pending`` is a simple attribute assignment and the overhead
+            is negligible.
+
+        .. note::
+            **Multi-fidelity mode**: ``encode_candidates`` requires every
+            candidate — including those in ``pending_candidates`` — to have a
+            ``fidelity`` value set. Passing candidates without fidelity in MF
+            mode will raise a ``ValueError``.
+
+        Parameters
+        ----------
+        candidates : Iterable[Candidate]
+            Candidates to score.
+        pending_candidates : Iterable[Candidate]
+            Candidates that have already been selected in the current batch but
+            not yet observed. The acquisition will condition on these.
+            In multi-fidelity mode every pending candidate must carry a
+            ``fidelity`` value.
+        cost_weighting : callable, optional
+            If provided, called as ``cost_weighting(raw_scores, candidates)``
+            after scoring.
+
+        Returns
+        -------
+        result : list[float]
+            Acquisition scores in the same order as ``candidates``.
+            All ``1.0`` when called before ``update()``.
+
+        Raises
+        ------
+        ValueError
+            If the surrogate was fitted in multi-fidelity mode and any candidate
+            in ``pending_candidates`` does not carry a fidelity value.
+        """
+        cand_list = list(candidates)
+        if not cand_list:
+            return []
+
+        pending_list = list(pending_candidates)
+        if not pending_list:
+            return self.score(cand_list, cost_weighting)
+
+        if self._botorch_acqf is None:
+            return [1.0] * len(cand_list)
+
+        assert self._botorch_surrogate is not None  # type: ignore[union-attr]
+
+        X = self._botorch_surrogate.encode_candidates(cand_list).unsqueeze(1)
+        X_pending = self._botorch_surrogate.encode_candidates(pending_list)
+
+        botorch_acqf = self._botorch_acqf
+        previous_pending = botorch_acqf.X_pending
+        botorch_acqf.set_X_pending(X_pending)
+        try:
+            raw_scores = self._score_encoded(X)
+        finally:
+            botorch_acqf.set_X_pending(previous_pending)
+
+        if cost_weighting is None:
+            return raw_scores
+        return cost_weighting(raw_scores, cand_list)
+
 
 class AnalyticBoTorchAcquisition(BoTorchAcquisitionBase):
     """Intermediate base class for analytic BoTorch acquisition functions.

--- a/src/activelearning/active_learning.py
+++ b/src/activelearning/active_learning.py
@@ -106,7 +106,7 @@ def active_learning(
         round_budget = budget.get_round_budget(num_rounds)
 
         # Pass acquisition, cost_fn, and round budget to selector for cost-aware selection
-        selected_samples = selector(
+        selected_samples = selector.select(
             samples,
             acquisition=acquisition,
             cost_fn=oracle.get_costs,

--- a/src/activelearning/selector/cost_aware_selector.py
+++ b/src/activelearning/selector/cost_aware_selector.py
@@ -12,7 +12,7 @@ class CostAwareSelector(Selector):
     budget is exhausted. Does not require a fixed number of samples.
     """
 
-    def __call__(
+    def select(
         self,
         candidates: Sequence[Candidate],
         acquisition: Optional[Acquisition] = None,

--- a/src/activelearning/selector/pending_aware_greedy_selector.py
+++ b/src/activelearning/selector/pending_aware_greedy_selector.py
@@ -1,0 +1,133 @@
+from typing import Any, Callable, Optional, Sequence
+
+from activelearning.selector.selector import Selector
+from activelearning.utils.types import Candidate
+
+
+class PendingAwareGreedyFantasySelector(Selector):
+    """Greedy selector that conditions on already-selected candidates at each step.
+
+    At each of up to ``k`` steps, the already-selected candidates are passed as
+    "pending" to the acquisition function, which conditions its scores on the
+    expected information gain from those pending observations before scoring the
+    remaining candidates. This avoids redundant selections by accounting for
+    inter-candidate dependencies.
+
+    Requires an acquisition that exposes ``supports_pending_scoring = True`` and
+    implements ``score_with_pending(candidates, pending_candidates)``. All
+    BoTorch-backed acquisitions satisfy this requirement.
+
+    Optional budget handling: if both ``cost_fn`` and ``round_budget`` are
+    provided, only candidates whose addition keeps the running total cost within
+    budget are considered feasible at each step.
+
+    Parameters
+    ----------
+    k : int
+        Maximum number of candidates to select per round.
+
+    Raises
+    ------
+    ValueError
+        If ``k < 1``.
+    """
+
+    def __init__(self, k: int) -> None:
+        if k < 1:
+            raise ValueError(f"k must be >= 1, got {k}.")
+        self.k = k
+
+    def select(
+        self,
+        candidates: Sequence[Candidate],
+        acquisition: Optional[Any] = None,
+        cost_fn: Optional[Callable[[Sequence[Candidate]], list[float]]] = None,
+        round_budget: Optional[float] = None,
+    ) -> list[Candidate]:
+        """Greedily select up to k candidates using pending-aware rescoring.
+
+        At each step the remaining candidates are rescored conditioned on the
+        candidates selected so far (the pending set). The highest-scoring
+        feasible candidate is added to the selection and the process repeats.
+
+        Parameters
+        ----------
+        candidates : Sequence[Candidate]
+            Pool of candidates to select from.
+        acquisition : Optional[Any]
+            Acquisition object with ``supports_pending_scoring = True`` and
+            a ``score_with_pending(candidates, pending_candidates)`` method.
+        cost_fn : Optional[Callable[[Sequence[Candidate]], list[float]]]
+            Function returning per-candidate costs. Must be provided together
+            with ``round_budget`` to enable budget-constrained selection.
+        round_budget : Optional[float]
+            Total budget for the selected set. Must be provided together with
+            ``cost_fn`` to enable budget-constrained selection.
+
+        Returns
+        -------
+        result : list[Candidate]
+            Selected candidates in greedy construction order. May contain
+            fewer than ``k`` candidates if the pool or budget is exhausted.
+
+        Raises
+        ------
+        ValueError
+            If ``acquisition`` is not provided, if the acquisition does not
+            support pending scoring, or if only one of ``cost_fn`` /
+            ``round_budget`` is supplied.
+        """
+        if acquisition is None:
+            raise ValueError(
+                f"{self.__class__.__name__} requires an acquisition function."
+            )
+        if not getattr(acquisition, "supports_pending_scoring", False):
+            raise ValueError(
+                f"{self.__class__.__name__} requires an acquisition that supports "
+                "pending-aware scoring (supports_pending_scoring=True). "
+                "All BoTorch acquisitions support this."
+            )
+
+        use_budget = (cost_fn is not None) or (round_budget is not None)
+        if use_budget and (cost_fn is None or round_budget is None):
+            raise ValueError(
+                "Both cost_fn and round_budget must be provided together for "
+                "budget-constrained selection."
+            )
+
+        remaining = list(candidates)
+        if not remaining:
+            return []
+
+        selected: list[Candidate] = []
+        spent = 0.0
+
+        while remaining and len(selected) < self.k:
+            if use_budget:
+                costs = cost_fn(remaining)  # type: ignore[misc]
+                if any(c < 0 for c in costs):
+                    raise ValueError("Cost function returned a negative cost.")
+                feasible_with_costs = [
+                    (cand, cost)
+                    for cand, cost in zip(remaining, costs)
+                    if spent + cost <= round_budget  # type: ignore[operator]
+                ]
+                if not feasible_with_costs:
+                    break
+                feasible = [cand for cand, _ in feasible_with_costs]
+                feasible_costs = [cost for _, cost in feasible_with_costs]
+            else:
+                feasible = remaining
+                feasible_costs = None
+
+            scores = acquisition.score_with_pending(feasible, list(selected))
+            best_idx = max(range(len(feasible)), key=lambda i: scores[i])
+            best = feasible[best_idx]
+            selected.append(best)
+
+            if use_budget:
+                spent += feasible_costs[best_idx]  # type: ignore[index]
+
+            remaining = [c for c in remaining if c is not best]
+
+        return selected

--- a/src/activelearning/selector/score_selector.py
+++ b/src/activelearning/selector/score_selector.py
@@ -17,7 +17,7 @@ class TopKAcquisitionSelector(Selector):
     def __init__(self, num_samples: int) -> None:
         self.num_samples = num_samples
 
-    def __call__(
+    def select(
         self,
         candidates: Sequence[Candidate],
         acquisition: Optional[Acquisition] = None,

--- a/src/activelearning/selector/selector.py
+++ b/src/activelearning/selector/selector.py
@@ -13,7 +13,7 @@ class Selector(ABC, ALRuntimeMixin):
     """
 
     @abstractmethod
-    def __call__(
+    def select(
         self,
         candidates: Sequence[Candidate],
         acquisition: Optional[Any] = None,
@@ -35,6 +35,7 @@ class Selector(ABC, ALRuntimeMixin):
         round_budget : Optional[float]
             Budget limit for this round (optional).
             Required by cost-aware selectors.
+
         Returns
         -------
         result : Sequence[Candidate]

--- a/tests/acquisition/test_botorch_acquisition.py
+++ b/tests/acquisition/test_botorch_acquisition.py
@@ -631,8 +631,114 @@ class TestQBatchScore:
 
 
 # ===================================================================
-# cost_fn post-processing
+# score_with_pending() — BoTorchAcquisitionBase
 # ===================================================================
+
+
+class TestScoreWithPending:
+    """Tests for score_with_pending() and supports_pending_scoring."""
+
+    def test_supports_pending_scoring_is_true(self) -> None:
+        """All BoTorch acquisitions report supports_pending_scoring=True."""
+        assert StubAnalytic().supports_pending_scoring is True
+        assert StubQBatch().supports_pending_scoring is True
+
+    def test_empty_candidates_returns_empty(
+        self,
+        fitted_surrogate: BoTorchGPSurrogate,
+        single_fidelity_observations: list[Observation],
+        candidates: list[Candidate],
+    ) -> None:
+        from activelearning.acquisition.botorch.botorch_qbatch import (
+            QExpectedImprovement,
+        )
+
+        acq = QExpectedImprovement()
+        acq.update(fitted_surrogate, single_fidelity_observations)
+        assert acq.score_with_pending([], candidates) == []
+
+    def test_empty_pending_falls_back_to_score(
+        self,
+        fitted_surrogate: BoTorchGPSurrogate,
+        single_fidelity_observations: list[Observation],
+        candidates: list[Candidate],
+    ) -> None:
+        """When pending is empty, score_with_pending returns the same as score()."""
+        from activelearning.acquisition.botorch.botorch_qbatch import (
+            QExpectedImprovement,
+        )
+
+        acq = QExpectedImprovement()
+        acq.update(fitted_surrogate, single_fidelity_observations)
+        assert acq.score_with_pending(candidates, []) == acq.score(candidates)
+
+    def test_returns_uniform_before_update(
+        self,
+        candidates: list[Candidate],
+    ) -> None:
+        """Returns [1.0] for every candidate before update(), matching score()."""
+        from activelearning.acquisition.botorch.botorch_qbatch import (
+            QExpectedImprovement,
+        )
+
+        acq = QExpectedImprovement()
+        scores = acq.score_with_pending(candidates, [candidates[0]])
+        assert scores == [1.0] * len(candidates)
+
+    def test_returns_one_score_per_candidate(
+        self,
+        fitted_surrogate: BoTorchGPSurrogate,
+        single_fidelity_observations: list[Observation],
+        candidates: list[Candidate],
+    ) -> None:
+        from activelearning.acquisition.botorch.botorch_qbatch import (
+            QExpectedImprovement,
+        )
+
+        acq = QExpectedImprovement()
+        acq.update(fitted_surrogate, single_fidelity_observations)
+        pending = [candidates[0]]
+        remaining = candidates[1:]
+        scores = acq.score_with_pending(remaining, pending)
+        assert len(scores) == len(remaining)
+
+    def test_x_pending_is_cleared_after_call(
+        self,
+        fitted_surrogate: BoTorchGPSurrogate,
+        single_fidelity_observations: list[Observation],
+        candidates: list[Candidate],
+    ) -> None:
+        """The BoTorch acqf's X_pending must be None after score_with_pending returns."""
+        from activelearning.acquisition.botorch.botorch_qbatch import (
+            QExpectedImprovement,
+        )
+
+        acq = QExpectedImprovement()
+        acq.update(fitted_surrogate, single_fidelity_observations)
+        acq.score_with_pending(candidates[1:], [candidates[0]])
+        assert acq._botorch_acqf.X_pending is None  # type: ignore[union-attr]
+
+    def test_x_pending_is_cleared_even_on_error(
+        self,
+        fitted_surrogate: BoTorchGPSurrogate,
+        single_fidelity_observations: list[Observation],
+        candidates: list[Candidate],
+    ) -> None:
+        """X_pending must be reset even when _score_encoded raises."""
+        from activelearning.acquisition.botorch.botorch_qbatch import (
+            QExpectedImprovement,
+        )
+
+        acq = QExpectedImprovement()
+        acq.update(fitted_surrogate, single_fidelity_observations)
+
+        def raise_on_call(X: Any) -> list[float]:
+            raise RuntimeError("simulated scoring failure")
+
+        acq._score_encoded = raise_on_call  # type: ignore[method-assign]
+        with pytest.raises(RuntimeError, match="simulated scoring failure"):
+            acq.score_with_pending(candidates[1:], [candidates[0]])
+        assert acq._botorch_acqf.X_pending is None  # type: ignore[union-attr]
 
 
 class TestCostWeightingPostProcessing:

--- a/tests/selector/test_cost_aware_selector.py
+++ b/tests/selector/test_cost_aware_selector.py
@@ -50,7 +50,7 @@ def varying_cost_fn():
 def test_raises_without_acquisition(selector, candidates, uniform_cost_fn):
     """Test that selector raises ValueError when acquisition is None."""
     with pytest.raises(ValueError, match="Acquisition function is required"):
-        selector(
+        selector.select(
             candidates, acquisition=None, cost_fn=uniform_cost_fn, round_budget=100.0
         )
 
@@ -58,7 +58,7 @@ def test_raises_without_acquisition(selector, candidates, uniform_cost_fn):
 def test_raises_without_cost_fn(selector, candidates, mock_acquisition):
     """Test that selector raises ValueError when cost_fn is None."""
     with pytest.raises(ValueError, match="Cost function is required"):
-        selector(
+        selector.select(
             candidates, acquisition=mock_acquisition, cost_fn=None, round_budget=100.0
         )
 
@@ -66,7 +66,7 @@ def test_raises_without_cost_fn(selector, candidates, mock_acquisition):
 def test_raises_without_budget(selector, candidates, mock_acquisition, uniform_cost_fn):
     """Test that selector raises ValueError when round_budget is None."""
     with pytest.raises(ValueError, match="Budget is required"):
-        selector(
+        selector.select(
             candidates,
             acquisition=mock_acquisition,
             cost_fn=uniform_cost_fn,
@@ -76,7 +76,7 @@ def test_raises_without_budget(selector, candidates, mock_acquisition, uniform_c
 
 def test_empty_candidates(selector, mock_acquisition, uniform_cost_fn):
     """Test selector returns empty list for empty candidates."""
-    result = selector(
+    result = selector.select(
         [], acquisition=mock_acquisition, cost_fn=uniform_cost_fn, round_budget=100.0
     )
     assert result == []
@@ -94,7 +94,7 @@ def test_selects_by_utility_cost_ratio(selector, candidates):
     def cost_fn(c):
         return [10.0, 5.0, 2.0, 1.0, 1.0]
 
-    selected = selector(
+    selected = selector.select(
         candidates, acquisition=acquisition, cost_fn=cost_fn, round_budget=100.0
     )
 
@@ -126,7 +126,7 @@ def test_stops_when_budget_exhausted(selector, candidates):
 
     # Budget is 3.0 - should select candidates 0 (cost 1) and 1 (cost 1), total 2.0
     # Cannot add candidate 2 (cost 2) as 2+2=4 > 3
-    selected = selector(
+    selected = selector.select(
         candidates, acquisition=acquisition, cost_fn=cost_fn, round_budget=3.0
     )
 
@@ -144,7 +144,7 @@ def test_uniform_costs_varying_utilities(selector, candidates, uniform_cost_fn):
     acquisition.score.return_value = [10.0, 20.0, 30.0, 40.0, 50.0]
 
     # Budget 12.0 allows 2 candidates (2 * 5.0 = 10.0)
-    selected = selector(
+    selected = selector.select(
         candidates, acquisition=acquisition, cost_fn=uniform_cost_fn, round_budget=12.0
     )
 
@@ -163,7 +163,7 @@ def test_varying_costs_uniform_utilities(selector, candidates, varying_cost_fn):
     acquisition.score.return_value = [100.0, 100.0, 100.0, 100.0, 100.0]
 
     # Budget 6.0 allows candidates 0 (cost 1), 1 (cost 2), 2 (cost 3) = 6.0 total
-    selected = selector(
+    selected = selector.select(
         candidates, acquisition=acquisition, cost_fn=varying_cost_fn, round_budget=6.0
     )
 
@@ -183,7 +183,7 @@ def test_zero_cost_candidate(selector):
     def cost_fn(c):
         return [0.0, 5.0, 10.0]  # First candidate has zero cost
 
-    selected = selector(
+    selected = selector.select(
         candidates, acquisition=acquisition, cost_fn=cost_fn, round_budget=15.0
     )
 
@@ -203,14 +203,14 @@ def test_negative_cost_candidate(selector):
         return [-5.0, 5.0, 10.0]  # First candidate has negative cost
 
     with pytest.raises(ValueError, match="negative cost"):
-        selector(
+        selector.select(
             candidates, acquisition=acquisition, cost_fn=cost_fn, round_budget=15.0
         )
 
 
 def test_zero_budget(selector, candidates, mock_acquisition, uniform_cost_fn):
     """Test that zero budget results in no selections."""
-    selected = selector(
+    selected = selector.select(
         candidates,
         acquisition=mock_acquisition,
         cost_fn=uniform_cost_fn,
@@ -231,7 +231,7 @@ def test_exact_budget_fit(selector):
         return [5.0, 5.0, 5.0]
 
     # Budget exactly 15.0 = 3 candidates * 5.0
-    selected = selector(
+    selected = selector.select(
         candidates, acquisition=acquisition, cost_fn=cost_fn, round_budget=15.0
     )
 
@@ -252,7 +252,7 @@ def test_greedy_not_optimal(selector):
     # Budget 10.0 - greedy by ratio picks candidate 1 first (ratio 9/5=1.8),
     # then cannot fit candidate 0 (cost 6.0) in the remaining budget.
     # The true max-utility feasible set is candidate 0 alone (utility 10.0 > 9.0).
-    selected = selector(
+    selected = selector.select(
         candidates, acquisition=acquisition, cost_fn=cost_fn, round_budget=10.0
     )
 

--- a/tests/selector/test_pending_aware_greedy_selector.py
+++ b/tests/selector/test_pending_aware_greedy_selector.py
@@ -1,0 +1,209 @@
+"""Tests for PendingAwareGreedyFantasySelector."""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from activelearning.selector.pending_aware_greedy_selector import (
+    PendingAwareGreedyFantasySelector,
+)
+from activelearning.utils.types import Candidate
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_candidates(n: int) -> list[Candidate]:
+    return [Candidate(x=[float(i)]) for i in range(n)]
+
+
+def make_acquisition(scores: list[float], supports_pending: bool = True) -> Any:
+    """Return a mock acquisition whose score_with_pending returns fixed scores."""
+    acq = MagicMock()
+    acq.supports_pending_scoring = supports_pending
+    acq.score_with_pending.side_effect = lambda candidates, pending: [
+        scores[int(c.x[0])] for c in candidates
+    ]
+    return acq
+
+
+def uniform_cost_fn(candidates: Any) -> list[float]:
+    return [1.0] * len(list(candidates))
+
+
+# ---------------------------------------------------------------------------
+# Construction validation
+# ---------------------------------------------------------------------------
+
+
+class TestConstruction:
+    def test_k_must_be_at_least_one(self) -> None:
+        with pytest.raises(ValueError, match="k must be >= 1"):
+            PendingAwareGreedyFantasySelector(k=0)
+
+    def test_negative_k_raises(self) -> None:
+        with pytest.raises(ValueError, match="k must be >= 1"):
+            PendingAwareGreedyFantasySelector(k=-1)
+
+    def test_valid_k_constructs(self) -> None:
+        sel = PendingAwareGreedyFantasySelector(k=3)
+        assert sel.k == 3
+
+
+# ---------------------------------------------------------------------------
+# Input validation inside select()
+# ---------------------------------------------------------------------------
+
+
+class TestSelectValidation:
+    def test_missing_acquisition_raises(self) -> None:
+        sel = PendingAwareGreedyFantasySelector(k=2)
+        with pytest.raises(ValueError, match="requires an acquisition"):
+            sel.select(make_candidates(3))
+
+    def test_acquisition_without_pending_support_raises(self) -> None:
+        sel = PendingAwareGreedyFantasySelector(k=2)
+        acq = make_acquisition([1.0, 2.0, 3.0], supports_pending=False)
+        with pytest.raises(ValueError, match="supports_pending_scoring"):
+            sel.select(make_candidates(3), acquisition=acq)
+
+    def test_cost_fn_without_budget_raises(self) -> None:
+        sel = PendingAwareGreedyFantasySelector(k=2)
+        acq = make_acquisition([1.0, 2.0, 3.0])
+        with pytest.raises(ValueError, match="Both cost_fn and round_budget"):
+            sel.select(make_candidates(3), acquisition=acq, cost_fn=uniform_cost_fn)
+
+    def test_budget_without_cost_fn_raises(self) -> None:
+        sel = PendingAwareGreedyFantasySelector(k=2)
+        acq = make_acquisition([1.0, 2.0, 3.0])
+        with pytest.raises(ValueError, match="Both cost_fn and round_budget"):
+            sel.select(make_candidates(3), acquisition=acq, round_budget=5.0)
+
+    def test_empty_candidates_returns_empty(self) -> None:
+        sel = PendingAwareGreedyFantasySelector(k=2)
+        acq = make_acquisition([])
+        assert sel.select([], acquisition=acq) == []
+
+
+# ---------------------------------------------------------------------------
+# Core greedy selection behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestGreedySelection:
+    def test_selects_k_candidates(self) -> None:
+        """Selector returns exactly k candidates from a larger pool."""
+        candidates = make_candidates(5)
+        scores = [1.0, 5.0, 3.0, 4.0, 2.0]
+        acq = make_acquisition(scores)
+        sel = PendingAwareGreedyFantasySelector(k=3)
+        result = sel.select(candidates, acquisition=acq)
+        assert len(result) == 3
+
+    def test_selects_best_first(self) -> None:
+        """First selected candidate is the globally highest scorer."""
+        candidates = make_candidates(4)
+        scores = [1.0, 4.0, 2.0, 3.0]
+        acq = make_acquisition(scores)
+        sel = PendingAwareGreedyFantasySelector(k=1)
+        result = sel.select(candidates, acquisition=acq)
+        assert result[0] == candidates[1]  # score 4.0
+
+    def test_returns_all_when_k_geq_pool_size(self) -> None:
+        candidates = make_candidates(3)
+        acq = make_acquisition([1.0, 2.0, 3.0])
+        sel = PendingAwareGreedyFantasySelector(k=10)
+        result = sel.select(candidates, acquisition=acq)
+        assert len(result) == 3
+
+    def test_no_duplicate_selections(self) -> None:
+        candidates = make_candidates(4)
+        acq = make_acquisition([1.0, 2.0, 3.0, 4.0])
+        sel = PendingAwareGreedyFantasySelector(k=4)
+        result = sel.select(candidates, acquisition=acq)
+        assert len(result) == len(set(id(c) for c in result))
+
+    def test_pending_grows_each_step(self) -> None:
+        """score_with_pending is called with a growing pending set."""
+        candidates = make_candidates(3)
+        scores = [3.0, 2.0, 1.0]
+        acq = make_acquisition(scores)
+        sel = PendingAwareGreedyFantasySelector(k=3)
+        sel.select(candidates, acquisition=acq)
+
+        calls = acq.score_with_pending.call_args_list
+        assert len(calls) == 3
+        # First call: no pending
+        assert list(calls[0].args[1]) == []
+        # Second call: 1 pending
+        assert len(calls[1].args[1]) == 1
+        # Third call: 2 pending
+        assert len(calls[2].args[1]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Budget-constrained selection
+# ---------------------------------------------------------------------------
+
+
+class TestBudgetConstrainedSelection:
+    def test_respects_budget(self) -> None:
+        """With unit costs and budget=2, exactly 2 candidates are selected."""
+        candidates = make_candidates(5)
+        acq = make_acquisition([5.0, 4.0, 3.0, 2.0, 1.0])
+        sel = PendingAwareGreedyFantasySelector(k=5)
+        result = sel.select(
+            candidates,
+            acquisition=acq,
+            cost_fn=uniform_cost_fn,
+            round_budget=2.0,
+        )
+        assert len(result) == 2
+
+    def test_returns_empty_when_all_unaffordable(self) -> None:
+        candidates = make_candidates(3)
+        acq = make_acquisition([3.0, 2.0, 1.0])
+        sel = PendingAwareGreedyFantasySelector(k=3)
+        result = sel.select(
+            candidates,
+            acquisition=acq,
+            cost_fn=lambda _: [10.0, 10.0, 10.0],
+            round_budget=5.0,
+        )
+        assert result == []
+
+    def test_selects_affordable_subset(self) -> None:
+        """With heterogeneous costs, skips candidates that would exceed budget."""
+        candidates = make_candidates(4)
+        # candidate 3 has score 4.0 but cost 10 — should be skipped
+        acq = make_acquisition([1.0, 2.0, 3.0, 4.0])
+        costs = [1.0, 1.0, 1.0, 10.0]
+
+        def cost_fn(cands: Any) -> list[float]:
+            return [costs[int(c.x[0])] for c in cands]
+
+        sel = PendingAwareGreedyFantasySelector(k=3)
+        result = sel.select(
+            candidates,
+            acquisition=acq,
+            cost_fn=cost_fn,
+            round_budget=3.0,
+        )
+        assert len(result) == 3
+        assert candidates[3] not in result
+
+    def test_negative_cost_raises(self) -> None:
+        """Negative costs are rejected with a ValueError."""
+        candidates = make_candidates(3)
+        acq = make_acquisition([3.0, 2.0, 1.0])
+        sel = PendingAwareGreedyFantasySelector(k=3)
+        with pytest.raises(ValueError, match="negative cost"):
+            sel.select(
+                candidates,
+                acquisition=acq,
+                cost_fn=lambda _: [1.0, -0.5, 1.0],
+                round_budget=5.0,
+            )

--- a/tests/selector/test_score_selector.py
+++ b/tests/selector/test_score_selector.py
@@ -40,7 +40,7 @@ def test_top_k_selection_by_score(
     selector, acquisition_with_surrogate, test_candidates
 ):
     """Test that selector returns top-k candidates by acquisition score."""
-    selected = selector(test_candidates, acquisition=acquisition_with_surrogate)
+    selected = selector.select(test_candidates, acquisition=acquisition_with_surrogate)
 
     expected_length = min(selector.num_samples, len(test_candidates))
     assert len(selected) == expected_length
@@ -51,7 +51,7 @@ def test_correct_ordering_highest_first(acquisition_with_surrogate):
     """Test that selected candidates are ordered by score (highest first)."""
     selector = TopKAcquisitionSelector(num_samples=3)
     candidates = [Candidate(x=1), Candidate(x=5), Candidate(x=10)]
-    selected = selector(candidates, acquisition=acquisition_with_surrogate)
+    selected = selector.select(candidates, acquisition=acquisition_with_surrogate)
 
     # Get acquisition values to verify ordering
     acq_values = acquisition_with_surrogate.score(selected)
@@ -65,7 +65,7 @@ def test_num_samples_exceeds_candidates_length(acquisition_with_surrogate):
     """Test that requesting more samples than candidates returns all."""
     selector = TopKAcquisitionSelector(num_samples=10)
     candidates = [Candidate(x=i) for i in range(5)]
-    selected = selector(candidates, acquisition=acquisition_with_surrogate)
+    selected = selector.select(candidates, acquisition=acquisition_with_surrogate)
 
     assert len(selected) == 5
 
@@ -86,7 +86,7 @@ def test_selection_with_varied_scores():
 
     selector = TopKAcquisitionSelector(num_samples=2)
     candidates = [Candidate(x=1), Candidate(x=2), Candidate(x=3), Candidate(x=4)]
-    selected = selector(candidates, acquisition=acquisition)
+    selected = selector.select(candidates, acquisition=acquisition)
 
     # Top 2 should be x=3 (200.0) and x=1 (100.0)
     assert len(selected) == 2

--- a/tests/test_active_learning.py
+++ b/tests/test_active_learning.py
@@ -169,7 +169,7 @@ def test_active_learning_stops_when_selector_returns_empty(
 ):
     """Test loop terminates when selector returns no candidates."""
     empty_selector = Mock()
-    empty_selector.return_value = []
+    empty_selector.select.return_value = []
 
     dataset_out, cost, num_iter = active_learning(
         dataset=dataset,
@@ -264,14 +264,14 @@ class RuntimeLoggingSampler(PoolScoreSampler):
 class RuntimeLoggingSelector(TopKAcquisitionSelector):
     """Selector test double that emits metrics through the bound runtime logger."""
 
-    def __call__(
+    def select(
         self,
         candidates: Sequence[Candidate],
         acquisition: Optional[DummyAcquisition] = None,
         cost_fn: Optional[Callable[[Sequence[Candidate]], list[float]]] = None,
         round_budget: Optional[float] = None,
     ) -> list[Candidate]:
-        selected = super().__call__(
+        selected = super().select(
             candidates,
             acquisition=acquisition,
             cost_fn=cost_fn,


### PR DESCRIPTION
# PR: Pending-aware greedy selector and `score_with_pending`

**Base branch:** `features/qbatch-acquisitions`  
**Head branch:** `features/pending-aware-selector`

---

## Summary

Adds pending-aware greedy batch construction: a selector that conditions
each candidate's score on the candidates already selected in the current
round. This avoids redundant selections by accounting for inter-candidate
dependencies via BoTorch's `set_X_pending` mechanism.

Also refactors the `Selector` ABC from `__call__` to an explicit
`select()` method for clarity and consistency.

---

## Changes

### `score_with_pending()` (`botorch_acquisition.py`)

New method on `BoTorchAcquisitionBase` enabling pending-aware singleton
scoring:

```python
scores = acquisition.score_with_pending(candidates, pending_candidates)
```

- Sets `X_pending` on the live BoTorch acquisition object via
  `set_X_pending()`, scores, then restores `X_pending = None` via
  `try/finally` (safe even if scoring raises).
- Falls back to `score()` when `pending_candidates` is empty.
- `supports_pending_scoring` property is always `True` for BoTorch
  acquisitions since all BoTorch acquisition functions expose
  `set_X_pending()`.
- Supports `cost_weighting` post-processing, matching the `score()` API.

### New file: `pending_aware_greedy_selector.py`

`PendingAwareGreedyFantasySelector` implements greedy batch construction:

1. At each step, score all remaining candidates conditioned on the
   already-selected set (via `score_with_pending`).
2. Select the highest-scoring feasible candidate.
3. Repeat up to `k` times or until the pool / budget is exhausted.

Supports optional budget-constrained selection when both `cost_fn` and
`round_budget` are provided.

### Selector ABC refactor (`selector.py`)

- Renamed `__call__` → `select()` on the abstract base class.
- Updated `TopKAcquisitionSelector`, `CostAwareSelector`, and all call
  sites (`active_learning.py`, tests).

---

## Design decisions

**Why `score_with_pending` on the acquisition rather than the selector?**  
The pending mechanism is a property of the acquisition function (it
requires `set_X_pending()` on the BoTorch object). Placing it on the
acquisition keeps the selector simple — it just calls
`score_with_pending` in a loop — and allows other selectors or user code
to reuse pending-aware scoring without duplicating the `set_X_pending` /
`try/finally` logic.

**Why `select()` instead of `__call__`?**  
An explicit method name is clearer for a public API. `__call__` obscures
the selector's role when reading `selector(candidates, ...)` vs
`selector.select(candidates, ...)`.

**Why duck-typed `supports_pending_scoring` rather than an ABC method?**  
Only BoTorch acquisitions support `set_X_pending`. Adding it to the
`Acquisition` ABC would force non-BoTorch implementations to stub out a
method they cannot meaningfully implement. The selector checks via
`getattr(acquisition, "supports_pending_scoring", False)`, which cleanly
rejects unsupported acquisitions with an informative error.

---

## Testing

- **`TestScoreWithPending`** (7 tests): empty input, empty pending
  fallback, pre-update error, one score per candidate, `X_pending`
  cleanup after success, `X_pending` cleanup after error,
  `supports_pending_scoring` flag.
- **`TestPendingAwareGreedyFantasySelector`** (16 tests):
  construction validation, input validation, greedy selection order,
  `k ≥ pool` handling, no duplicates, pending set growth verification,
  budget constraints (respects budget, all unaffordable, heterogeneous
  costs).
- Updated existing selector tests for `__call__` → `select()` rename.

**432 tests passing.**

