### PR TITLE
Multi-fidelity environment wrapper

### DIFF
--- a/src/activelearning/sampler/gflownet/gflownet_sampler.py
+++ b/src/activelearning/sampler/gflownet/gflownet_sampler.py
@@ -1,10 +1,14 @@
-import torch
+from functools import partial
 from typing import Any, Iterable, Optional
+
+import torch
 from omegaconf import DictConfig
-from activelearning.sampler.sampler import Sampler
-from activelearning.sampler.gflownet.logger_wrapper import (
-    RuntimeGFlowNetLoggerWrapper,
+
+from activelearning.sampler.gflownet.logger_wrapper import RuntimeGFlowNetLoggerWrapper
+from activelearning.sampler.gflownet.multi_fidelity_env_wrapper import (
+    MultiFidelityGFlowNetEnvWrapper,
 )
+from activelearning.sampler.sampler import Sampler
 from activelearning.utils.types import Candidate, Observation
 
 
@@ -29,6 +33,8 @@ class GFlowNetSampler(Sampler):
         Torch device string (e.g. ``"cpu"`` or ``"cuda"``).
     float_precision : int
         Floating-point precision (32 or 64).
+    n_fidelities : int
+        Number of fidelities. By default, 1 (single fidelity).
     """
 
     def __init__(
@@ -37,6 +43,7 @@ class GFlowNetSampler(Sampler):
         conf: DictConfig,
         device: str,
         float_precision: int,
+        n_fidelities: int = 1,
     ) -> None:
         import hydra
 
@@ -45,11 +52,15 @@ class GFlowNetSampler(Sampler):
         self._gflownet_device = device
         self._gflownet_float_precision = float_precision
 
-        self.env_maker = hydra.utils.instantiate(
+        env_base = hydra.utils.instantiate(
             self.conf.env,
             device=self._gflownet_device,
             float_precision=self._gflownet_float_precision,
-            _partial_=True,
+        )
+        self.env_maker = partial(
+            MultiFidelityGFlowNetEnvWrapper,
+            env_base=env_base,
+            n_fidelities=n_fidelities,
         )
         env = self.env_maker()
 

--- a/src/activelearning/sampler/gflownet/gflownet_sampler.py
+++ b/src/activelearning/sampler/gflownet/gflownet_sampler.py
@@ -52,14 +52,15 @@ class GFlowNetSampler(Sampler):
         self._gflownet_device = device
         self._gflownet_float_precision = float_precision
 
-        env_base = hydra.utils.instantiate(
+        env_base_maker = hydra.utils.instantiate(
             self.conf.env,
             device=self._gflownet_device,
             float_precision=self._gflownet_float_precision,
+            _partial=True,
         )
         self.env_maker = partial(
             MultiFidelityGFlowNetEnvWrapper,
-            env_base=env_base,
+            env_base_maker=env_base_maker,
             n_fidelities=n_fidelities,
         )
         env = self.env_maker()

--- a/src/activelearning/sampler/gflownet/multi_fidelity_env_wrapper.py
+++ b/src/activelearning/sampler/gflownet/multi_fidelity_env_wrapper.py
@@ -1,10 +1,65 @@
+from typing import Any, List, Sequence, Tuple
+
 from gflownet.envs.base import GFlowNetEnv
 from gflownet.envs.choice import Choice
+from gflownet.envs.composite.base import CompositeBase
 from gflownet.envs.composite.setfix import SetFix
 from gflownet.envs.composite.stack import Stack
 
 
-class MultiFidelityGFlowNetEnvWrapper(SetFix):
+class MultiFidelityGFlowNetEnvWrapperBase(CompositeBase):
+    """Common base environment for all the multi-fidelity environment wrappers"""
+
+    def get_states_base_and_fidelities(
+        self, states: Sequence
+    ) -> Tuple[List[Any], List[int]]:
+        """Retrieves the states of the base env and the fidelities of a batch of
+        states.
+
+        Parameters
+        ----------
+        states : Sequence
+            A batch of states in environment format.
+
+        Returns
+        -------
+        states_base : List[Any]
+            The states of the base environment in the batch.
+        fidelities : List[int]
+            The fidelity index in each state of the batch.
+        """
+        states_base = []
+        fidelities = []
+        for state in states:
+            states_base.append(self._get_substate(state, self.idx_base_env))
+            fidelities.append(self._get_substate(state, self.idx_fidelity)[0])
+        return states_base, fidelities
+
+    def get_state_base_and_fidelity(self, state: Any = None) -> Tuple[Any, int]:
+        """Retrieves the state of the base env and the fidelity of a state.
+
+        This method constructs a dummy batch with the input state and calls
+        ``get_states_base_and_fidelities()``; then returns the first element of the
+        output.
+
+        Parameters
+        ----------
+        states : Any or ``None``
+            A state in environment format. If ``None``, ``self.state`` is used.
+
+        Returns
+        -------
+        states_base : Any
+            The state of the base environment.
+        fidelities : int
+            The fidelity index in the input state.
+        """
+        state = self._get_state(state)
+        states_base, fidelities = self.get_states_base_and_fidelities([state])
+        return states_base[0], fidelities[0]
+
+
+class MultiFidelityGFlowNetEnvWrapper(SetFix, MultiFidelityGFlowNetEnvWrapperBase):
     """Turns any GFlowNet environment into a multi-fidelity environment.
 
     The wrapper is a SetFix GFlowNet environment whose sub-environments are the
@@ -18,11 +73,15 @@ class MultiFidelityGFlowNetEnvWrapper(SetFix):
         **kwargs,
     ) -> None:
         self.env_base = env_base
-        self.fidelity_env = Choice(n_options=n_fidelities)
-        super().__init__(subenvs=tuple([self.env_base, self.fidelity_env]), **kwargs)
+        self.env_fidelity = Choice(n_options=n_fidelities)
+        self.idx_base_env = 0
+        self.idx_fidelity = 1
+        super().__init__(subenvs=tuple([self.env_base, self.env_fidelity]), **kwargs)
 
 
-class MultiFidelityGFlowNetEnvWrapperFidFirst(Stack):
+class MultiFidelityGFlowNetEnvWrapperFidFirst(
+    Stack, MultiFidelityGFlowNetEnvWrapperBase
+):
     """Turns any GFlowNet environment into a multi-fidelity environment.
 
     The wrapper is a Stack GFlowNet environment whose sub-environments are:
@@ -40,11 +99,15 @@ class MultiFidelityGFlowNetEnvWrapperFidFirst(Stack):
         **kwargs,
     ) -> None:
         self.env_base = env_base
-        self.fidelity_env = Choice(n_options=n_fidelities)
-        super().__init__(subenvs=tuple([self.fidelity_env, self.env_base]), **kwargs)
+        self.env_fidelity = Choice(n_options=n_fidelities)
+        self.idx_fidelity = 0
+        self.idx_base_env = 1
+        super().__init__(subenvs=tuple([self.env_fidelity, self.env_base]), **kwargs)
 
 
-class MultiFidelityGFlowNetEnvWrapperFidLast(Stack):
+class MultiFidelityGFlowNetEnvWrapperFidLast(
+    Stack, MultiFidelityGFlowNetEnvWrapperBase
+):
     """Turns any GFlowNet environment into a multi-fidelity environment.
 
     The wrapper is a Stack GFlowNet environment whose sub-environments are:
@@ -62,5 +125,7 @@ class MultiFidelityGFlowNetEnvWrapperFidLast(Stack):
         **kwargs,
     ) -> None:
         self.env_base = env_base
-        self.fidelity_env = Choice(n_options=n_fidelities)
-        super().__init__(subenvs=tuple([self.env_base, self.fidelity_env]), **kwargs)
+        self.env_fidelity = Choice(n_options=n_fidelities)
+        self.idx_base_env = 0
+        self.idx_fidelity = 1
+        super().__init__(subenvs=tuple([self.env_base, self.env_fidelity]), **kwargs)

--- a/src/activelearning/sampler/gflownet/multi_fidelity_env_wrapper.py
+++ b/src/activelearning/sampler/gflownet/multi_fidelity_env_wrapper.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Sequence, Tuple
+from typing import Any, List, Sequence, Tuple, Type
 
 from gflownet.envs.base import GFlowNetEnv
 from gflownet.envs.choice import Choice
@@ -64,15 +64,37 @@ class MultiFidelityGFlowNetEnvWrapper(SetFix, MultiFidelityGFlowNetEnvWrapperBas
 
     The wrapper is a SetFix GFlowNet environment whose sub-environments are the
     base environment and a Choice environment to model the discrete fidelity index.
+
+        Parameters
+        ----------
+        env_base : GFlowNetEnv
+        An instance of the base environment.
+    env_fidelity : Choice
+        An instance of a Choice environment to model the choice of fidelity index.
+    idx_base_env : int
+        The sub-environment index corresponding to the base environment. It is set to
+        0, arbitrarily.
+    idx_fidelity : int
+        The sub-environment index corresponding to the fidelity environment. It is set
+        to 1, arbitrarily.
     """
 
     def __init__(
         self,
-        env_base: GFlowNetEnv,
+        env_base_maker: Type[GFlowNetEnv],
         n_fidelities: int,
         **kwargs,
     ) -> None:
-        self.env_base = env_base
+        """Initializes a MultiFidelityGFlowNetEnvWrapper instance.
+
+        Parameters
+        ----------
+        env_base_maker : Type[GFlowNetEnv]
+            An environment maker (partial) to instantiate the base environment.
+        n_fidelities : int
+            The number of possible fidelity indices.
+        """
+        self.env_base = env_base_maker()
         self.env_fidelity = Choice(n_options=n_fidelities)
         self.idx_base_env = 0
         self.idx_fidelity = 1
@@ -90,15 +112,37 @@ class MultiFidelityGFlowNetEnvWrapperFidFirst(
 
     Therefore, the fidelity is sampled first, followed by the actions of the base
     environment.
+
+        Parameters
+        ----------
+        env_base : GFlowNetEnv
+        An instance of the base environment.
+    env_fidelity : Choice
+        An instance of a Choice environment to model the choice of fidelity index.
+    idx_fidelity : int
+        The sub-environment index corresponding to the fidelity environment. It is set
+        to 0 because the fidelity is the first sub-environment.
+    idx_base_env : int
+        The sub-environment index corresponding to the base environment. It is set to
+        1 because the base environment is sampled only after the fidelity.
     """
 
     def __init__(
         self,
-        env_base: GFlowNetEnv,
+        env_base_maker: Type[GFlowNetEnv],
         n_fidelities: int,
         **kwargs,
     ) -> None:
-        self.env_base = env_base
+        """Initializes a MultiFidelityGFlowNetEnvWrapperFidFirst instance.
+
+        Parameters
+        ----------
+        env_base_maker : Type[GFlowNetEnv]
+            An environment maker (partial) to instantiate the base environment.
+        n_fidelities : int
+            The number of possible fidelity indices.
+        """
+        self.env_base = env_base_maker()
         self.env_fidelity = Choice(n_options=n_fidelities)
         self.idx_fidelity = 0
         self.idx_base_env = 1
@@ -116,15 +160,37 @@ class MultiFidelityGFlowNetEnvWrapperFidLast(
 
     Therefore, the actions of the base environment are sampled first, and the fidelity
     is sampled at the end of the trajectory.
+
+        Parameters
+        ----------
+        env_base : GFlowNetEnv
+        An instance of the base environment.
+    env_fidelity : Choice
+        An instance of a Choice environment to model the choice of fidelity index.
+    idx_base_env : int
+        The sub-environment index corresponding to the base environment. It is set to
+        0 because the base environment is sampled first, before the fidelity.
+    idx_fidelity : int
+        The sub-environment index corresponding to the fidelity environment. It is set
+        to 1 because the fidelity is sampled only after the base environment.
     """
 
     def __init__(
         self,
-        env_base: GFlowNetEnv,
+        env_base_maker: Type[GFlowNetEnv],
         n_fidelities: int,
         **kwargs,
     ) -> None:
-        self.env_base = env_base
+        """Initializes a MultiFidelityGFlowNetEnvWrapperFidLast instance.
+
+        Parameters
+        ----------
+        env_base_maker : Type[GFlowNetEnv]
+            An environment maker (partial) to instantiate the base environment.
+        n_fidelities : int
+            The number of possible fidelity indices.
+        """
+        self.env_base = env_base_maker()
         self.env_fidelity = Choice(n_options=n_fidelities)
         self.idx_base_env = 0
         self.idx_fidelity = 1

--- a/src/activelearning/sampler/gflownet/multi_fidelity_env_wrapper.py
+++ b/src/activelearning/sampler/gflownet/multi_fidelity_env_wrapper.py
@@ -65,9 +65,9 @@ class MultiFidelityGFlowNetEnvWrapper(SetFix, MultiFidelityGFlowNetEnvWrapperBas
     The wrapper is a SetFix GFlowNet environment whose sub-environments are the
     base environment and a Choice environment to model the discrete fidelity index.
 
-        Parameters
-        ----------
-        env_base : GFlowNetEnv
+    Parameters
+    ----------
+    env_base : GFlowNetEnv
         An instance of the base environment.
     env_fidelity : Choice
         An instance of a Choice environment to model the choice of fidelity index.
@@ -113,9 +113,9 @@ class MultiFidelityGFlowNetEnvWrapperFidFirst(
     Therefore, the fidelity is sampled first, followed by the actions of the base
     environment.
 
-        Parameters
-        ----------
-        env_base : GFlowNetEnv
+    Parameters
+    ----------
+    env_base : GFlowNetEnv
         An instance of the base environment.
     env_fidelity : Choice
         An instance of a Choice environment to model the choice of fidelity index.
@@ -161,9 +161,9 @@ class MultiFidelityGFlowNetEnvWrapperFidLast(
     Therefore, the actions of the base environment are sampled first, and the fidelity
     is sampled at the end of the trajectory.
 
-        Parameters
-        ----------
-        env_base : GFlowNetEnv
+    Parameters
+    ----------
+    env_base : GFlowNetEnv
         An instance of the base environment.
     env_fidelity : Choice
         An instance of a Choice environment to model the choice of fidelity index.

--- a/src/activelearning/sampler/gflownet/multi_fidelity_env_wrapper.py
+++ b/src/activelearning/sampler/gflownet/multi_fidelity_env_wrapper.py
@@ -1,0 +1,66 @@
+from gflownet.envs.base import GFlowNetEnv
+from gflownet.envs.choice import Choice
+from gflownet.envs.composite.setfix import SetFix
+from gflownet.envs.composite.stack import Stack
+
+
+class MultiFidelityGFlowNetEnvWrapper(SetFix):
+    """Turns any GFlowNet environment into a multi-fidelity environment.
+
+    The wrapper is a SetFix GFlowNet environment whose sub-environments are the
+    base environment and a Choice environment to model the discrete fidelity index.
+    """
+
+    def __init__(
+        self,
+        env_base: GFlowNetEnv,
+        n_fidelities: int,
+        **kwargs,
+    ) -> None:
+        self.env_base = env_base
+        self.fidelity_env = Choice(n_options=n_fidelities)
+        super().__init__(subenvs=tuple([self.env_base, self.fidelity_env]), **kwargs)
+
+
+class MultiFidelityGFlowNetEnvWrapperFidFirst(Stack):
+    """Turns any GFlowNet environment into a multi-fidelity environment.
+
+    The wrapper is a Stack GFlowNet environment whose sub-environments are:
+        1. A Choice environment to model the discrete fidelity index.
+        2. The base environment.
+
+    Therefore, the fidelity is sampled first, followed by the actions of the base
+    environment.
+    """
+
+    def __init__(
+        self,
+        env_base: GFlowNetEnv,
+        n_fidelities: int,
+        **kwargs,
+    ) -> None:
+        self.env_base = env_base
+        self.fidelity_env = Choice(n_options=n_fidelities)
+        super().__init__(subenvs=tuple([self.fidelity_env, self.env_base]), **kwargs)
+
+
+class MultiFidelityGFlowNetEnvWrapperFidLast(Stack):
+    """Turns any GFlowNet environment into a multi-fidelity environment.
+
+    The wrapper is a Stack GFlowNet environment whose sub-environments are:
+        1. The base environment.
+        2. A Choice environment to model the discrete fidelity index.
+
+    Therefore, the actions of the base environment are sampled first, and the fidelity
+    is sampled at the end of the trajectory.
+    """
+
+    def __init__(
+        self,
+        env_base: GFlowNetEnv,
+        n_fidelities: int,
+        **kwargs,
+    ) -> None:
+        self.env_base = env_base
+        self.fidelity_env = Choice(n_options=n_fidelities)
+        super().__init__(subenvs=tuple([self.env_base, self.fidelity_env]), **kwargs)

--- a/src/activelearning/sampler/gflownet/multi_fidelity_env_wrapper.py
+++ b/src/activelearning/sampler/gflownet/multi_fidelity_env_wrapper.py
@@ -65,7 +65,7 @@ class MultiFidelityGFlowNetEnvWrapper(SetFix, MultiFidelityGFlowNetEnvWrapperBas
     The wrapper is a SetFix GFlowNet environment whose sub-environments are the
     base environment and a Choice environment to model the discrete fidelity index.
 
-    Parameters
+    Attributes
     ----------
     env_base : GFlowNetEnv
         An instance of the base environment.
@@ -113,7 +113,7 @@ class MultiFidelityGFlowNetEnvWrapperFidFirst(
     Therefore, the fidelity is sampled first, followed by the actions of the base
     environment.
 
-    Parameters
+    Attributes
     ----------
     env_base : GFlowNetEnv
         An instance of the base environment.
@@ -161,7 +161,7 @@ class MultiFidelityGFlowNetEnvWrapperFidLast(
     Therefore, the actions of the base environment are sampled first, and the fidelity
     is sampled at the end of the trajectory.
 
-    Parameters
+    Attributes
     ----------
     env_base : GFlowNetEnv
         An instance of the base environment.

--- a/tests/sampler/gflownet/test_multi_fidelity_env_wrapper.py
+++ b/tests/sampler/gflownet/test_multi_fidelity_env_wrapper.py
@@ -137,3 +137,82 @@ def test__env_wrapper_set_initializes_properly(env_base, n_fidelities, request):
     env_base = request.getfixturevalue(env_base)
     env = MultiFidelityGFlowNetEnvWrapper(env_base=env_base, n_fidelities=n_fidelities)
     assert isinstance(env, GFlowNetEnv)
+
+
+@pytest.mark.parametrize(
+    "env_base",
+    [
+        "env_grid2d",
+        "env_cube3d",
+        "env_choice",
+        "env_stack_cube_setgrids",
+        "env_stack_cube_setstacks",
+        "env_set_cubes",
+    ],
+)
+@pytest.mark.parametrize(
+    "n_fidelities",
+    [
+        1,
+        3,
+    ],
+)
+def test__get_states_base_and_fidelities_returns_expected(
+    env_base, n_fidelities, request
+):
+    env_base = request.getfixturevalue(env_base)
+    env = MultiFidelityGFlowNetEnvWrapper(env_base=env_base, n_fidelities=n_fidelities)
+
+    # Sample a batch of random states
+    n_states = 10
+    states = []
+    states_base_expected = []
+    fidelities_expected = []
+    for _ in range(n_states):
+        env.get_random_states(n_states=1)
+        states.append(env.state)
+        states_base_expected.append(env.env_base.state)
+        fidelity = env.env_fidelity.state[0]
+        assert fidelity in range(n_fidelities + 1)
+        fidelities_expected.append(fidelity)
+
+    # Retrieve base states and fidelities using env wrapper method
+    states_base, fidelities = env.get_states_base_and_fidelities(states)
+
+    # Check equality
+    for state, state_exp in zip(states_base, states_base_expected):
+        assert env.env_base.equal(state, state_exp)
+    assert fidelities == fidelities_expected
+
+
+@pytest.mark.parametrize(
+    "env_base",
+    [
+        "env_grid2d",
+        "env_cube3d",
+        "env_choice",
+        "env_stack_cube_setgrids",
+        "env_stack_cube_setstacks",
+        "env_set_cubes",
+    ],
+)
+@pytest.mark.parametrize(
+    "n_fidelities",
+    [
+        1,
+        3,
+    ],
+)
+def test__get_state_base_and_fidelity_returns_expected(env_base, n_fidelities, request):
+    env_base = request.getfixturevalue(env_base)
+    env = MultiFidelityGFlowNetEnvWrapper(env_base=env_base, n_fidelities=n_fidelities)
+
+    n_states = 10
+    for _ in range(n_states):
+        env.get_random_states(n_states=1)
+        state_base_expected = env.env_base.state
+        fidelity_expected = env.env_fidelity.state[0]
+        assert fidelity_expected in range(n_fidelities + 1)
+        state_base, fidelity = env.get_state_base_and_fidelity(env.state)
+        assert env.env_base.equal(state_base, state_base_expected)
+        assert fidelity == fidelity_expected

--- a/tests/sampler/gflownet/test_multi_fidelity_env_wrapper.py
+++ b/tests/sampler/gflownet/test_multi_fidelity_env_wrapper.py
@@ -228,10 +228,10 @@ def test__env_maker_creates_independent_env_base_instances():
     and corrupts all others. env_maker() must therefore construct a fresh env_base on
     every call.
     """
-    env_base = Grid(n_dim=2, length=3)
+    env_base = partial(Grid, n_dim=2, length=3)
 
     env_maker = partial(
-        MultiFidelityGFlowNetEnvWrapper, env_base=env_base, n_fidelities=2
+        MultiFidelityGFlowNetEnvWrapper, env_base_maker=env_base, n_fidelities=2
     )
 
     env1 = env_maker()

--- a/tests/sampler/gflownet/test_multi_fidelity_env_wrapper.py
+++ b/tests/sampler/gflownet/test_multi_fidelity_env_wrapper.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 import pytest
 from gflownet.envs.base import GFlowNetEnv
 from gflownet.envs.choice import Choice
@@ -216,3 +218,29 @@ def test__get_state_base_and_fidelity_returns_expected(env_base, n_fidelities, r
         state_base, fidelity = env.get_state_base_and_fidelity(env.state)
         assert env.env_base.equal(state_base, state_base_expected)
         assert fidelity == fidelity_expected
+
+
+def test__env_maker_creates_independent_env_base_instances():
+    """Each call to env_maker() must produce a wrapper with an independent env_base.
+
+    If env_base is instantiated once and shared across wrappers (e.g. captured in a
+    functools.partial), sampling a trajectory through one wrapper moves env_base.state
+    and corrupts all others. env_maker() must therefore construct a fresh env_base on
+    every call.
+    """
+    env_base = Grid(n_dim=2, length=3)
+
+    env_maker = partial(
+        MultiFidelityGFlowNetEnvWrapper, env_base=env_base, n_fidelities=2
+    )
+
+    env1 = env_maker()
+    env2 = env_maker()
+
+    # Each wrapper must hold its own independent env_base instance.
+    assert env1.env_base is not env2.env_base
+
+    # Advancing env1 must leave env2's base state untouched.
+    initial_state = list(env2.env_base.state)
+    env1.get_random_states(n_states=1)
+    assert env2.env_base.equal(env2.env_base.state, initial_state)

--- a/tests/sampler/gflownet/test_multi_fidelity_env_wrapper.py
+++ b/tests/sampler/gflownet/test_multi_fidelity_env_wrapper.py
@@ -1,0 +1,139 @@
+import pytest
+from gflownet.envs.base import GFlowNetEnv
+from gflownet.envs.choice import Choice
+from gflownet.envs.composite.setfix import SetFix
+from gflownet.envs.composite.stack import Stack
+from gflownet.envs.cube import ContinuousCube
+from gflownet.envs.grid import Grid
+
+from activelearning.sampler.gflownet.multi_fidelity_env_wrapper import (
+    MultiFidelityGFlowNetEnvWrapper,
+)
+
+
+@pytest.fixture
+def env_grid2d():
+    return Grid(n_dim=2, length=3)
+
+
+@pytest.fixture
+def env_cube3d():
+    return ContinuousCube(n_dim=3)
+
+
+@pytest.fixture
+def env_choice():
+    return Choice(n_options=5)
+
+
+@pytest.fixture
+def env_stack_cube_setgrids():
+    """
+    Stack of cube and set of grids, to test compositionality of meta environments.
+    0: Cube
+    1: SetFix
+        0: Grid
+        1: Grid
+    """
+    return Stack(
+        subenvs=(
+            ContinuousCube(n_dim=2),
+            SetFix(
+                subenvs=(
+                    Grid(n_dim=2, length=3),
+                    Grid(n_dim=2, length=3),
+                )
+            ),
+        )
+    )
+
+
+@pytest.fixture
+def env_stack_cube_setstacks():
+    """
+    Stack of set of stacks, to test compositionality of meta environments.
+    0: Cube
+    1: SetFix
+        Stack
+            0: Cube
+            1: Grid
+        Stack
+            0: Grid
+            1: Cube
+    """
+    return Stack(
+        subenvs=(
+            ContinuousCube(n_dim=2),
+            SetFix(
+                subenvs=(
+                    Stack(
+                        subenvs=(
+                            ContinuousCube(n_dim=2),
+                            Grid(n_dim=2, length=3),
+                        )
+                    ),
+                    Stack(
+                        subenvs=(
+                            Grid(n_dim=2, length=3),
+                            ContinuousCube(n_dim=2),
+                        )
+                    ),
+                )
+            ),
+        )
+    )
+
+
+@pytest.fixture
+def env_set_cubes():
+    """Set of three 2D cubes."""
+    return SetFix(
+        subenvs=(
+            ContinuousCube(n_dim=2),
+            ContinuousCube(n_dim=2),
+            ContinuousCube(n_dim=2),
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "env",
+    [
+        "env_grid2d",
+        "env_cube3d",
+        "env_choice",
+        "env_stack_cube_setgrids",
+        "env_stack_cube_setstacks",
+        "env_set_cubes",
+    ],
+)
+def test__base_envs_initialize_properly(env, request):
+    env = request.getfixturevalue(env)
+    assert True
+
+
+@pytest.mark.parametrize(
+    "env_base",
+    [
+        "env_grid2d",
+        "env_cube3d",
+        "env_choice",
+        "env_stack_cube_setgrids",
+        "env_stack_cube_setstacks",
+        "env_set_cubes",
+    ],
+)
+@pytest.mark.parametrize(
+    "n_fidelities",
+    [
+        1,
+        2,
+        3,
+        5,
+        10,
+    ],
+)
+def test__env_wrapper_set_initializes_properly(env_base, n_fidelities, request):
+    env_base = request.getfixturevalue(env_base)
+    env = MultiFidelityGFlowNetEnvWrapper(env_base=env_base, n_fidelities=n_fidelities)
+    assert isinstance(env, GFlowNetEnv)


### PR DESCRIPTION
This PR initiates the implementation of a wrapper for GFlowNet environments to incorporate the sampling of a fidelity index in the trajectory of any GFlowNet environment.

The multi-fidelity wrapper (MF wrapper) relies on the Composite environments [implemented in the gflownet library](https://github.com/alexhernandezgarcia/gflownet/tree/main/gflownet/envs/composite). In particular, the MF wrapper is a Composite environment consisting of the base environment and a fidelity environment implemented as a [Choice](https://github.com/alexhernandezgarcia/gflownet/blob/main/gflownet/envs/choice.py) environment. This means that the trajectories of the resulting MF wrapper environment will sample the actions to unfold a trajectory of the base environment, as well as the selection of the fidelity index.

This initial implementation defaults to using a [Set](https://github.com/alexhernandezgarcia/gflownet/blob/main/gflownet/envs/composite/setfix.py) as the wrapper, meaning that the fidelity action is not forced to be selected at either the beginning or the end. Instead, it can be chosen at any point in the trajectory. This default implementation corresponds to the wrapper environment `MultiFidelityGFlowNetEnvWrapper`. However, this PR also implements `MultiFidelityGFlowNetEnvWrapperFidFirst` and `MultiFidelityGFlowNetEnvWrapperFidLast`, which are [Stacks](https://github.com/alexhernandezgarcia/gflownet/blob/main/gflownet/envs/composite/stack.py) and enforce that the fidelity is selected before and after, respectively, the actions of the base environment.

This PR does **not** complete the implementation of the GFlowNet sampler into the framework, which is why the base branch is `gflownet_sampler` and not `main`.